### PR TITLE
Fix Backbone Detection

### DIFF
--- a/extension/js/backboneAgent/build.js
+++ b/extension/js/backboneAgent/build.js
@@ -15,9 +15,14 @@
  */
 
 // @include utils.js
+// @include utils/watchers/stopWatching.js
+// @include utils/watchers/onObjectAndPropertiesSetted.js
+
 // @include data.js
 // @include base.js
 // @include logic.js
+
+
 
 
 /*

--- a/extension/js/backboneAgent/utils/watchers/onObjectAndPropertiesSetted.js
+++ b/extension/js/backboneAgent/utils/watchers/onObjectAndPropertiesSetted.js
@@ -1,0 +1,42 @@
+/**
+  * Monitors for an object and its properties being defined.*
+  *
+  * For example, if we want to know when Backbone and Backbone.View,Model,.. are defined*
+  * We could do  onObjectAndPropertiesSetted(window, 'Backbone', ['View', 'Model'], function(Backbone) {})
+  *
+  * And, when Backbone is fully defined, the callback will be invoked.*
+  * We do this by watching first for Backbone being defined, then it's properties.
+  */
+
+var onObjectAndPropertiesSetted = function(parentObject, objectName, properties, callback) {
+  function onObjectSet(prop, action, newVal, oldVal) {
+    function onPropertySet(prop2, action2, newVal2, oldVal2) {//
+
+      // exists is separate than has, because not only
+      // do we want the prop set, but it must be more than undefiened
+      function exists(obj, prop) {
+        return !_.isUndefined(obj[prop])
+      }
+
+      var allPropertiesSet = _.all(properties, _.partial(exists, newVal));
+      if (!allPropertiesSet) {
+        return;
+      }
+
+      // clean up all of the defined property poop
+      _.each(properties, function(_prop, key) {//
+        stopWatching(newVal, _prop, onPropertySet);
+      });
+
+      stopWatching(parentObject, objectName, onObjectSet);
+
+      callback(newVal)
+    }
+
+    _.each(properties, function(prop) {
+      watch(newVal, prop, onPropertySet, 0);
+    }, this, parentObject, objectName, properties, newVal, callback);
+  }
+
+  watch(parentObject, objectName, onObjectSet, 0);
+}

--- a/extension/js/backboneAgent/utils/watchers/stopWatching.js
+++ b/extension/js/backboneAgent/utils/watchers/stopWatching.js
@@ -1,0 +1,18 @@
+ /*
+ *
+ * StopWatching will cleanup the watchers for an object property.
+ *
+ * There are two parts to this:
+ *  1. remove watchers set by watch
+ *  2. cleanup the getter, setter properties *
+ *
+ */
+
+var stopWatching = function(object, prop, callback) {
+  unwatch(object, prop, callback);
+  var tmp = object[prop];
+  delete object[prop];
+  object[prop] = tmp;
+
+  return object[prop]
+}


### PR DESCRIPTION
There are two ways that we detect Backbone in the app. (AMD, and `window.Backbone`).

Previously we were detecting `window.Backbone` when it was first set (`Backbone = {}`). This PR, fixes that by adding a super smart `objectPropSet` listener for watching for when an object and it's props are set. 

There are also some small cleanups here, but that's mostly it. 
