### PR TITLE
Update appObserver.regionTree to check for rootView

### DIFF
--- a/extension/js/backboneAgent/marionette/actions/highlightEl.js
+++ b/extension/js/backboneAgent/marionette/actions/highlightEl.js
@@ -1,4 +1,9 @@
 var highlightEl = function($el) {
+  if (!$el) {
+    return;
+  }
+
   $el.addClass('marionette-inspector-highlighted-element');
+
   debug.log('highlight', $el.get(0));
 }

--- a/extension/js/backboneAgent/marionette/actions/search.js
+++ b/extension/js/backboneAgent/marionette/actions/search.js
@@ -8,7 +8,7 @@
  * 3. show the region path in the bottom left
  */
 var search = function(appObserver, app) {
-    var regionTree = regionInspector(app, '', false);
+    var regionTree = appObserver.regionTree();
     var views = appObserver.viewList();
 
     var $els = [];
@@ -41,7 +41,7 @@ var search = function(appObserver, app) {
             // showViewSummary(view);
             sendAppComponentReport('search', {
               name: 'mouseover',
-              cid: cid 
+              cid: cid
             })
         });
 
@@ -54,7 +54,7 @@ var search = function(appObserver, app) {
 
             sendAppComponentReport('search', {
               name: 'mouseleave',
-              cid: cid 
+              cid: cid
             })
         });
 
@@ -72,7 +72,7 @@ var search = function(appObserver, app) {
 
             sendAppComponentReport('search', {
               name: 'mousedown',
-              cid: cid 
+              cid: cid
             });
 
             return false;

--- a/extension/js/backboneAgent/marionette/actions/stopSearch.js
+++ b/extension/js/backboneAgent/marionette/actions/stopSearch.js
@@ -4,7 +4,7 @@
  *
  */
 var stopSearch = function(appObserver, app) {
-    var regionTree = regionInspector(app, '', false);
+    var regionTree = appObserver.regionTree();
     var views = viewList(regionTree);
     var $els = $(_.pluck(views, 'el'));
 

--- a/extension/js/backboneAgent/marionette/actions/unhighlightEl.js
+++ b/extension/js/backboneAgent/marionette/actions/unhighlightEl.js
@@ -1,4 +1,8 @@
 var unhighlightEl = function($el) {
-	$el.removeClass('marionette-inspector-highlighted-element');
-	 debug.log('unhighlight', $el.get(0));
+	if (!$el) {
+    return;
+  }
+
+  $el.removeClass('marionette-inspector-highlighted-element');
+	debug.log('unhighlight', $el.get(0));
 }

--- a/extension/js/backboneAgent/marionette/appObserver.js
+++ b/extension/js/backboneAgent/marionette/appObserver.js
@@ -12,12 +12,6 @@ _.extend(AppObserver.prototype, {
   // expresion that's eval'd on the window to get the radio
   radioExpression: "app.wreqr",
 
-  // called by inspector to get the current region tree
-  regionTree: function(path) {//
-    path = path || '';
-    return regionInspector(this.getApp(), path, true);
-  },
-
   startSearch: function() {
     search(this, this.getApp());
   },
@@ -38,11 +32,26 @@ _.extend(AppObserver.prototype, {
 
   unhighlightView: function(data) {
     var view = this.getView(data.viewPath);
-    unhighlightEl(view.$el)
+    unhighlightEl(view.$el);
+    return false;
+  },
+
+  // called by inspector to get the current region tree
+  regionTree: function(path, shouldSerialize) {
+    shouldSerialize = !_.isUndefined(shouldSerialize) ? shouldSerialize : true;
+    path = path || '';
+    var app = this.getApp();
+    var tree = regionInspector(app, path, shouldSerialize);
+
+    if (_.isEmpty(tree)) {
+      tree = regionInspector(app.rootView, path, shouldSerialize);
+    }
+
+    return tree;
   },
 
   getView: function(path) {
-    var subTree = regionInspector(this.getApp(), path);
+    var subTree = this.regionTree(path, false);
 
     if (!subTree._view) {
       throw new Error('could not find view');
@@ -52,7 +61,7 @@ _.extend(AppObserver.prototype, {
   },
 
   viewList: function() {
-    var regionTree = regionInspector(app, '', false);
+    var regionTree = this.regionTree('', false);
     return viewList(regionTree);
   },
 

--- a/extension/js/backboneAgent/marionette/utils/regionInspector.js
+++ b/extension/js/backboneAgent/marionette/utils/regionInspector.js
@@ -1,19 +1,18 @@
 
-var regionInspector = function(app, path, shouldSerialize) {
+var regionInspector = function(regionTreeRoot, path, shouldSerialize) {
   shouldSerialize = !!shouldSerialize;
 
-  var regions = _regionInspector(app, shouldSerialize)
+  var regions = _regionInspector(regionTreeRoot, shouldSerialize)
 
   if (!!path) {
     regions = objectPath(regions, path, {});
   }
 
-  debug.log('ri: ', regions);
+  debug.log('region inspector: ', regions);
   return regions;
 };
 
 var _regionInspector = function (obj, shouldSerialize) {
-
 
   if (!obj) {
     return {};

--- a/extension/js/backboneAgent/patches/patchBackbone.js
+++ b/extension/js/backboneAgent/patches/patchBackbone.js
@@ -5,3 +5,4 @@ var patchBackbone = function(callback) {
     callback
   );
 }
+

--- a/extension/js/devTools/client.js
+++ b/extension/js/devTools/client.js
@@ -47,7 +47,7 @@ define([
         .then(this.waitForAppLoad)
         .then(this.exec.bind(this, _appObserverCall, [fnc, _.rest(arguments)]))
         .catch(function(e) {
-          logger.log('client', 'fetchData failed to get data', e.message);
+          logger.log('client', 'appObserverCall failed to make call', e.message);
         });
     },
 


### PR DESCRIPTION
This change does two nice things:
1. it removes the internal calls to `regionInspector` and instead goes through the `appObserver` `regionTree`. This is a boon because it's important to be consistent in the way we get a `regionTree`.
2. if the regionTree is empty we try to build a region tree off of the rootView. 
