### PR TITLE
Add collection and composite views to the region tree

### DIFF
--- a/extension/js/agent/marionette/utils/regionInspector.js
+++ b/extension/js/agent/marionette/utils/regionInspector.js
@@ -32,9 +32,14 @@ var _regionInspector = function (obj, shouldSerialize) {
   } else if (obj.children) { // collection view
     debug.log('ri: found collection view');
 
-    return _.map(obj.children._views, function(view) {
-      return _regionInspector(view, shouldSerialize);
-    }, this, _regionInspector, shouldSerialize);
+    var subViews = {};
+    _.each(obj.children._views, function(view, index) {
+      subViews[index] = _regionInspector(view, shouldSerialize);
+    }, this, subViews, _regionInspector, shouldSerialize);
+
+    subViews._view =  shouldSerialize ? viewSerializer(obj) :  obj;
+    debugger;
+    return subViews;
 
   } else { // simple view
     debug.log('ri: found simple view');


### PR DESCRIPTION
This fixes a bug where we were not capturing the collectionviews in the region tree.

If you look at the code, you'll see that when we found a collection view we'd get the children and return an array of subviews for each child. Now, what we do is make an object for sub views and add each child to that object along with the collection view indexed as `_view`. 

This is also nice idiomatically because, the regionTree will now be a tree all the way down and not really this hybrid with arrays where we found collection views.

Thanks @jdaudier for reporting!
