### PR TITLE
Send actions for view remove and model destroy

### DIFF
--- a/extension/js/agent/components/addAppComponentAction.js
+++ b/extension/js/agent/components/addAppComponentAction.js
@@ -13,14 +13,18 @@ var addAppComponentAction = bind(function(appComponent, appComponentAction) {
     var actionIndex = appComponentInfo.actions.length-1;
 
     // invia un report riguardante la nuova azione
-    var reportName = appComponentInfo.category+":"+appComponentInfo.index+":action";
-    sendAppComponentReport(reportName, {
+    var reportName = appComponentInfo.category+":"+appComponentAction.type;
+    var reportData = {
         componentActionIndex: actionIndex,
         type: appComponentAction.type,
-        name: appComponentAction.name
+        name: appComponentAction.name,
+        data: {
+            cid: appComponent.cid // might not exist
+        }
+    };
 
-    });
-    //debug.log("New action: ", appComponentAction);
+    sendAppComponentReport(reportName, reportData);
+    debug.log("action: ", reportName);
 
     return actionIndex;
 }, this);

--- a/extension/js/agent/patches/patchBackboneModel.js
+++ b/extension/js/agent/patches/patchBackboneModel.js
@@ -1,3 +1,17 @@
+var patchModelDestroy = function(originalFunction) {
+  return function() {
+    var appComponent = this;
+    var result = originalFunction.apply(this, arguments);
+
+    addAppComponentAction(this, new AppComponentAction(
+      "destroy", ""
+    ));
+
+    return result;
+  }
+}
+
+
 // @private
 this.patchBackboneModel = function(BackboneModel) {
     debug.log("Backbone.Model detected");
@@ -21,5 +35,7 @@ this.patchBackboneModel = function(BackboneModel) {
         patchAppComponentTrigger(model);
         patchAppComponentEvents(model);
         patchAppComponentSync(model);
+        patchFunctionLater(model, "destroy", patchModelDestroy);
+
     }, this));
 }

--- a/extension/js/agent/patches/patchBackboneView.js
+++ b/extension/js/agent/patches/patchBackboneView.js
@@ -1,10 +1,24 @@
+var patchViewRemove = function(originalFunction) {
+  return function() {
+    var appComponent = this;
+    var result = originalFunction.apply(appComponent, arguments);
+
+    addAppComponentAction(appComponent, new AppComponentAction(
+      "remove", ""
+    ));
+
+    return result;
+  }
+}
+
 // @private
 this.patchBackboneView = function(BackboneView) {
     debug.log("Backbone.View detected");
 
     patchBackboneComponent(BackboneView, bind(function(view) { // on new instance
         // registra il nuovo componente dell'app
-        var viewIndex = registerAppComponent("View", view);
+        var data = this.serializeView(view);
+        var viewIndex = registerAppComponent("View", view, data);
 
         // monitora i cambiamenti alle proprietà d'interesse del componente dell'app
         // monitorAppComponentProperty(view, "model", 0);
@@ -82,14 +96,6 @@ this.patchBackboneView = function(BackboneView) {
             return result;
         }});
 
-        patchFunctionLater(view, "remove", function(originalFunction) { return function() {
-            var result = originalFunction.apply(this, arguments);
-
-            addAppComponentAction(this, new AppComponentAction(
-                "operation", "remove"
-            ));
-
-            return result;
-        }});
+        patchFunctionLater(view, "remove", patchViewRemove);
     }, this));
 }

--- a/extension/js/inspector/app/modules/Data.js
+++ b/extension/js/inspector/app/modules/Data.js
@@ -12,7 +12,8 @@ define([
     channelName: 'data',
 
     clientEvents: {
-      'agent:Model:new': 'onNewModel'
+      'agent:Model:new': 'onModelNew',
+      'agent:Model:destroy': 'onModelDestroy'
     },
 
     initialize: function() {
@@ -27,11 +28,24 @@ define([
       Marionette.bindEntityEvents(this, this.client, this.clientEvents);
     },
 
-    onNewModel: function (event) {
-      logger.log('data', 'new model', event);
+    onModelNew: function (event) {
+      logger.log('data', 'model:new', event.data.cid);
 
       var modelData = event.data;
       this.modelCollection.add(modelData);
+    },
+
+    onModelDestroy: function (event) {
+      var cid = event.data.cid;
+      logger.log('data', 'model:destroy', cid);
+
+      var model = this.modelCollection.findWhere({cid: cid});
+      if (!model) {
+        logger.log('data', 'model:destroy could not find model');
+        return;
+      }
+
+      model.set('isDestroyed', true)
     },
 
     startModule: function() {

--- a/extension/js/inspector/app/modules/UI.js
+++ b/extension/js/inspector/app/modules/UI.js
@@ -7,6 +7,7 @@ define([
   'client',
   'app/modules/UI/views/Layout',
   'app/modules/UI/models/UiData',
+  'app/modules/UI/models/ViewCollection',
   'app/modules/UI/util/ComponentReportToRegionTreeMap'
 ], function(
   Marionette,
@@ -17,6 +18,7 @@ define([
   client,
   Layout,
   UiData,
+  ViewCollection,
   ComponentReportToRegionTreeMap
 ) {
 
@@ -37,7 +39,9 @@ define([
     },
 
     clientEvents: {
-      'agent:search': 'onSearch'
+      'agent:search': 'onSearch',
+      'agent:View:new': 'onViewNew',
+      'agent:View:remove': 'onViewRemove'
     },
 
     regionTreeEvents: {
@@ -56,6 +60,7 @@ define([
     setupData: function() {
       this.uiData = new UiData();
       this.viewList = new Backbone.Collection();
+      this.viewCollection = new ViewCollection();
       this.moduleData = new Backbone.Model({
         searchOn: false
       });
@@ -68,6 +73,29 @@ define([
       var regionTreeEvents = new ComponentReportToRegionTreeMap();
       Marionette.bindEntityEvents(this, regionTreeEvents, this.regionTreeEvents);
     },
+
+
+    onViewNew: function (event) {
+      logger.log('ui', 'new view', event);
+
+      var viewData = event.data;
+      this.viewCollection.add(viewData);
+    },
+
+
+    onViewRemove: function (event) {
+      var cid = event.data.cid;
+      logger.log('ui', 'onViewRemove', cid);
+
+      var view = this.viewCollection.findWhere({cid: cid});
+      if (!view) {
+        logger.log('ui', 'onViewRemove could not find view');
+        return;
+      }
+
+      view.set('isRemoved', true)
+    },
+
 
     /*
      * regionTree events come from the ComponentReportToRegionTreeMap

--- a/extension/js/inspector/app/modules/UI/models/ViewCollection.js
+++ b/extension/js/inspector/app/modules/UI/models/ViewCollection.js
@@ -1,0 +1,10 @@
+define([
+  'backbone',
+  'app/modules/UI/models/ViewModel'
+], function(Backbone, ViewModel) {
+
+  return Backbone.Collection.extend({
+    model: ViewModel
+  });
+
+})

--- a/extension/js/inspector/app/modules/UI/models/ViewModel.js
+++ b/extension/js/inspector/app/modules/UI/models/ViewModel.js
@@ -1,0 +1,6 @@
+define([
+  'backbone'
+], function(Backbone) {
+  return Backbone.Model.extend({
+  });
+})


### PR DESCRIPTION
This PR lays the foundation for a more responsive UI and Data pane. 
- send a "new" view component report
- send a "remove" view component action
- send a "destroy" model component action
- save new views to a new `viewCollection`

With this new functionality, the data pane can stop showing destroyed models. And, the UI pane wont have to get all of the region tree data every time there's an update to the tree. Instead, we'll just have to send over a list of views in the current tree and for each view, it's region path and order (1st, 2nd in the tree).

As a general note, now that we're sending "new" view and model components over the wire, we should be cognizant that main of these events will be sent to the inspector when the inspector isn't on. So, the inspector will need to ask the agent for a list of views and models as welll. This feature, will be coming next.
