### PR TITLE
[inspector] fill out radio pane

### DIFF
--- a/extension/css/devtools.css
+++ b/extension/css/devtools.css
@@ -20,18 +20,20 @@ body {
 [view="app-layout"],
 .app-layout-body,
 [data-region="tool"],
-[view="ui-layout"], [view="data-layout"] {
+[view="ui-layout"], [view="data-layout"], [view="radio-layout"], {
   height: inherit;
 }
 
 [data-region="view-list"], [data-region="view-more-info"],
-[data-region="model-list"], [data-region="model-more-info"] {
+[data-region="model-list"], [data-region="model-more-info"],
+[data-region="channel-list"], [data-region="channel-more-info"] {
   height: inherit;
   overflow-y: scroll;
 }
 
 [data-region="view-more-info"],
-[data-region="model-info"] {
+[data-region="model-info"],
+[data-region="channel-info"] {
   padding: 0;
 }
 

--- a/extension/js/agent/marionette/serialize/serializeChannel.js
+++ b/extension/js/agent/marionette/serialize/serializeChannel.js
@@ -8,6 +8,7 @@ this.serializeChannel = function(channel) {
   data.commands = {};
   data.events = {};
   data.requests = {};
+  data.channelName = channel.channelName;
 
   _.each(getCommands(channel), function(command, commandName) {
     data.commands[commandName] = {
@@ -30,7 +31,7 @@ this.serializeChannel = function(channel) {
 
    _.each(eventHandlers, function(eventHandler) {
     eventHandlerList.push({
-      eventName: eventName,
+      name: eventName,
       context: this.contextData(eventHandler.context),
       callback: this.inspectValue(eventHandler.callback)
     });

--- a/extension/js/agent/patches/patchBackboneWreqr.js
+++ b/extension/js/agent/patches/patchBackboneWreqr.js
@@ -38,43 +38,35 @@ this.onNewChannel = function(channel, channelName) {
 }
 
 this.onRequestChange = function(channel, newValue, prop, action, difference, oldvalue) {
-  var data = {
+  sendAppComponentReport('Channel:change', {
     channelName: channel.channelName,
-    channel: this.serializeChannel(channel)
-  };
-
-  sendAppComponentReport('Channel:Change', data);
-  debug.log('channel request change', data);
+    data: this.serializeChannel(channel)
+  });
+  debug.log('channel request change', channel.channelName);
 };
 
 this.onCommandChange = function(channel, newValue, prop, action, difference, oldvalue) {
-  var data = {
+  sendAppComponentReport('Channel:change', {
     channelName: channel.channelName,
-    channel: this.serializeChannel(channel)
-  };
-
-  sendAppComponentReport('Channel:Change', data);
-  debug.log('channel command change', data);
+    data: this.serializeChannel(channel)
+  });
+  debug.log('channel command change', channel.channelName);
 };
 
 this.onEventChange = function(channel, newValue, prop, action, difference, oldvalue) {
-  var data = {
+  sendAppComponentReport('Channel:change', {
     channelName: channel.channelName,
-    channel: this.serializeChannel(channel)
-  };
-
-  sendAppComponentReport('Channel:Change', data);
-  debug.log('channel event change', data);
+    data: this.serializeChannel(channel)
+  });
+  debug.log('channel event change', channel.channelName);
 };
 
 this.reportNewChannel = function(channel, channelName) {
-  var data = {
+  sendAppComponentReport('Channel:new', {
     channelName: channel.channelName,
-    channel: this.serializeChannel(channel)
-  };
-
-  sendAppComponentReport('Channel:New', data);
-  debug.log('new channel', data);
+    data: this.serializeChannel(channel)
+  });
+  debug.log('new channel', channel.channelName);
 };
 
 

--- a/extension/js/inspector/app.js
+++ b/extension/js/inspector/app.js
@@ -69,7 +69,7 @@ define([
 
     navigate: function(route) {
       logger.log('app', 'navigate', route);
-      this.router.navigate(route, {trigger: true});
+      this.router.navigate(route, {trigger: true, replace: true});
     }
 
   });

--- a/extension/js/inspector/app/modules/Radio.js
+++ b/extension/js/inspector/app/modules/Radio.js
@@ -2,20 +2,39 @@ define([
   'marionette',
   'util/Radio',
   'logger',
+  'client',
   'app/modules/Module',
-  'app/modules/Radio/views/Layout'
-], function(Marionette, Radio, logger, Module, Layout) {
+  'app/modules/Radio/views/Layout',
+  'app/modules/Radio/models/ChannelCollection',
+], function(Marionette, Radio, logger, client, Module, Layout, ChannelCollection) {
   return Module.extend({
 
     channelName: 'radio',
 
+    clientEvents: {
+      'agent:Channel:new': 'onChannelNew',
+      'agent:Channel:change': 'onChannelChange'
+    },
+
     initialize: function() {
+      this.client = client;
     },
 
     setupData: function() {
+      this.channelCollection = new ChannelCollection();
     },
 
     setupEvents: function() {
+      Marionette.bindEntityEvents(this, this.client, this.clientEvents);
+    },
+
+    onChannelChange: function (event) {
+      var channel = this.channelCollection.findChannel(event.channelName);
+      channel.set(event.data);
+    },
+
+    onChannelNew: function(event) {
+      this.channelCollection.add([event.data]);
     },
 
     startModule: function() {
@@ -24,6 +43,7 @@ define([
 
     buildLayout: function() {
       return new Layout({
+        channelCollection: this.channelCollection
       });
     },
 

--- a/extension/js/inspector/app/modules/Radio/models/ChannelCollection.js
+++ b/extension/js/inspector/app/modules/Radio/models/ChannelCollection.js
@@ -1,0 +1,14 @@
+define([
+  'backbone',
+  'app/modules/Radio/models/ChannelModel'
+], function(Backbone, ChannelModel) {
+
+  return Backbone.Collection.extend({
+    model: ChannelModel,
+
+    findChannel: function(channelName) {
+      return this.findWhere({channelName: channelName});
+    }
+  });
+
+})

--- a/extension/js/inspector/app/modules/Radio/models/ChannelModel.js
+++ b/extension/js/inspector/app/modules/Radio/models/ChannelModel.js
@@ -1,0 +1,6 @@
+define([
+  'backbone'
+], function(Backbone) {
+  return Backbone.Model.extend({
+  });
+})

--- a/extension/js/inspector/app/modules/Radio/views/ChannelInfo.js
+++ b/extension/js/inspector/app/modules/Radio/views/ChannelInfo.js
@@ -1,0 +1,24 @@
+define([
+  'marionette',
+  'util/Radio',
+  "text!templates/devTools/radio/info.html",
+  'app/behaviors/SidebarPanes'
+], function(Marionette, Radio, tpl, SidebarPanesBehavior) {
+
+  return Marionette.ItemView.extend({
+
+    template: tpl,
+
+    behaviors: {
+      sidebarPanes: {
+        behaviorClass: SidebarPanesBehavior,
+      }
+    },
+
+    serializeData: function() {
+      var data = {};
+      _.extend(data, this.serializeModel(this.model));
+      return data;
+    }
+  });
+})

--- a/extension/js/inspector/app/modules/Radio/views/ChannelList.js
+++ b/extension/js/inspector/app/modules/Radio/views/ChannelList.js
@@ -1,0 +1,22 @@
+define([
+  'marionette',
+  'text!templates/devTools/radio/list.html',
+  'app/modules/Radio/views/ChannelRow',
+], function(Marionette, tpl, ChannelRow) {
+
+  return Marionette.CompositeView.extend({
+    template: tpl,
+
+    className: 'row',
+
+    childViewContainer: '[data-child-view-container]',
+
+    attributes: {
+      view: 'list'
+    },
+
+    childView: ChannelRow,
+
+  });
+
+})

--- a/extension/js/inspector/app/modules/Radio/views/ChannelRow.js
+++ b/extension/js/inspector/app/modules/Radio/views/ChannelRow.js
@@ -1,0 +1,55 @@
+define([
+  'marionette',
+  'text!templates/devTools/radio/row.html',
+  'util/Radio',
+], function(Marionette, tpl, Radio) {
+  return Marionette.ItemView.extend({
+    template: tpl,
+
+    tagName: 'tr',
+
+    className: 'channel-row',
+
+    ui: {
+      moreInfoLink: "[data-action='info']",
+    },
+
+    events: {
+      "click @ui.moreInfoLink": "onClickInfo",
+      "mouseover": 'onMouseOver',
+      "mouseleave": 'onMouseLeave'
+    },
+
+    onClickInfo: function() {
+      this.highlightRow();
+
+      if (!this.model.has('channelName')) {
+        return;
+      }
+
+      Radio.command('radio', 'show:info', this.model);
+    },
+
+    onMouseOver: function() {
+      this.highlightRow();
+    },
+
+    onMouseLeave: function() {
+      this.unhighlightRow();
+    },
+
+    highlightRow: function() {
+      this.$el.addClass('bg-info');
+    },
+
+    unhighlightRow: function() {
+      this.$el.removeClass('bg-info');
+    },
+
+    serializeData: function() {
+      var data = {};
+      _.extend(data, this.serializeModel(this.model));
+      return data;
+    }
+  });
+})

--- a/extension/js/inspector/app/modules/Radio/views/Channelnfo.js
+++ b/extension/js/inspector/app/modules/Radio/views/Channelnfo.js
@@ -1,0 +1,25 @@
+define([
+  'marionette',
+  'util/Radio',
+  "text!templates/devTools/radio/info.html",
+  'app/behaviors/SidebarPanes'
+], function(Marionette, Radio, tpl, SidebarPanesBehavior) {
+
+  return Marionette.ItemView.extend({
+
+    template: tpl,
+
+    behaviors: {
+      sidebarPanes: {
+        behaviorClass: SidebarPanesBehavior,
+      }
+    },
+
+    serializeData: function() {
+      var data = {};
+      _.extend(data, this.serializeModel(this.model));
+
+      return data;
+    }
+  });
+})

--- a/extension/js/inspector/app/modules/Radio/views/Layout.js
+++ b/extension/js/inspector/app/modules/Radio/views/Layout.js
@@ -1,13 +1,43 @@
-define(['marionette', "text!templates/devTools/radio/layout.html"], function(Marionette, tpl) {
+define([
+  'marionette',
+  "text!templates/devTools/radio/layout.html",
+  "util/Radio",
+  'app/modules/Radio/views/ChannelList',
+  'app/modules/Radio/views/ChannelInfo',
+], function(Marionette, tpl, Radio, ChannelList, ChannelInfo) {
 
   return Marionette.LayoutView.extend({
 
     template: tpl,
 
     regions: {
+      channelList: '[data-region="channel-list"]',
+      channelInfo: '[data-region="channel-info"]',
     },
 
-    onShow: function() {
+    attributes: {
+      view: 'radio-layout'
+    },
+
+    radioCommands: {
+      'show:info': 'showInfo'
+    },
+
+    initialize: function(options) {
+      Radio.connectCommands('radio', this.radioCommands, this);
+    },
+
+    onRender: function() {
+      this.getRegion('channelList').show(new ChannelList({
+        collection: this.options.channelCollection
+      }))
+    },
+
+    showInfo: function(channelModel) {
+      this.getRegion('channelInfo').show(new ChannelInfo({
+        model: channelModel
+      }));
     }
+
   });
 });

--- a/extension/js/inspector/main.js
+++ b/extension/js/inspector/main.js
@@ -93,7 +93,7 @@ require([
         app.module('UI', UIApp);
         app.module('Activity', ActivityApp);
         app.once('client:page:ready', function () {
-          app.navigate('ui');
+          app.navigate('ui', {trigger: true, replace: true});
         });
     });
 

--- a/extension/templates/devTools/radio/info.html
+++ b/extension/templates/devTools/radio/info.html
@@ -1,0 +1,57 @@
+<div class="sidebar-pane-stack flex-auto visible">
+
+  <div class="sidebar-pane-title expanded" tabindex="0">
+    Events
+  </div>
+  <div class="sidebar-pane visible">
+    <div class="body">
+      <div class="section expanded">
+        <ol class="properties properties-tree monospace">
+          {{#each events}}{{#each this}}
+          <li title="" style="">
+            <span class="name">{{name}}</span><span class="separator">: </span>
+            <span class="value console-formatted-undefined" title="undefined"> {{callback.inspect}} </span>
+          </li>
+          {{/each}}{{/each}}
+        </ol>
+      </div>
+    </div>
+  </div>
+
+  <div class="sidebar-pane-title expanded" tabindex="0">
+    Commands
+  </div>
+  <div class="sidebar-pane visible">
+    <div class="body">
+      <div class="section expanded">
+        <ol class="properties properties-tree monospace">
+          {{#each commands}}
+          <li title="" style="">
+            <span class="name">{{name}}</span><span class="separator">: </span>
+            <span class="value console-formatted-undefined" title="undefined"> {{context.type}} {{callback.inspect}} </span>
+          </li>
+          {{/each}}
+        </ol>
+      </div>
+    </div>
+  </div>
+
+  <div class="sidebar-pane-title expanded" tabindex="0">
+    Requests
+  </div>
+  <div class="sidebar-pane visible">
+    <div class="body">
+      <div class="section expanded">
+        <ol class="properties properties-tree monospace">
+          {{#each requests}}
+          <li title="" style="">
+            <span class="name">{{name}}</span><span class="separator">: </span>
+            <span class="value console-formatted-undefined" title="undefined">{{context.type}} {{callback.inspect}} </span>
+          </li>
+          {{/each}}
+        </ol>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/extension/templates/devTools/radio/layout.html
+++ b/extension/templates/devTools/radio/layout.html
@@ -1,14 +1,2 @@
-<div class="row">
-  <div class="col-xs-12">
-
-    <div class="panel panel-primary" style="margin-top:20px;">
-      <div class="panel-heading">Coming Soon!</div>
-      <div class="panel-body">
-        <p>
-          The Radio pane is under active development and will be coming soon.
-        </p>
-      </div>
-    </div>
-
-  </div>
-</div>
+<div data-region="channel-list" class="col-xs-5"></div>
+<div data-region="channel-info" class="col-xs-7"></div>

--- a/extension/templates/devTools/radio/list.html
+++ b/extension/templates/devTools/radio/list.html
@@ -1,0 +1,10 @@
+<table class="table">
+<thead>
+  <tr>
+    <th>Channels</th>
+    <th></th>
+  </tr>
+</thead>
+<tbody data-child-view-container>
+</tbody>
+</table>

--- a/extension/templates/devTools/radio/row.html
+++ b/extension/templates/devTools/radio/row.html
@@ -1,0 +1,7 @@
+<td data-action="info">
+  <a href="#">{{channelName}}</a>
+</td>
+
+<td>
+  <a data-action="log-channel" href="#">$</a>
+</td>


### PR DESCRIPTION
This gets us a pretty Radio panel with all the channels and their respective events, commands, and requests.
![](http://f.cl.ly/items/3N3i1n3g2s0Q3T0u0V2z/Image%202014-11-06%20at%2012.07.42%20PM.png)

I almost feel bad having y'all read this because like the other inspector PRs it's long and not all that interesting. You can imagine possible cleanup/refactors that extract common layout/list/row/info behaviors and base classes while you read it. Maybe we'll do this in the end, maybe we wont... Honestly, I kinda like looking at these semi-big views bc they're so easy on the eyes compared to all the agent code that's dense...
