### PR TITLE
[agent] Only patch deps once

### DIFF
--- a/extension/js/agent/patches/patchBackbone.js
+++ b/extension/js/agent/patches/patchBackbone.js
@@ -1,5 +1,11 @@
 
 this.patchBackbone = function(Backbone) {
+
+  if (this.patchedBackbone) {
+    debug.log('Backbone was detected again');
+    return;
+  }
+
   var Backbone = this.patchedBackbone = Backbone;
 
   debug.log("Backbone detected: ", Backbone);

--- a/extension/js/agent/patches/patchMarionette.js
+++ b/extension/js/agent/patches/patchMarionette.js
@@ -1,4 +1,10 @@
 this.patchMarionette = function(Backbone, Marionette) {
+
+  if (this.patchedMarionette) {
+    debug.log('Backbone was detected again');
+    return;
+  }
+
   var Marionette = this.patchedMarionette = Marionette;
   debug.log("Marionette detected: ", Marionette);
 


### PR DESCRIPTION
I think it's likely that if Backbone is set on the window and passed through define, we'll attempt to patch it twice. 

If you use the new `start()` method we could try to patch it twice.

If you use `localAgent` and `agent` we'll try to patch it twice.

all of these things are bad and we should guard against them. This does that 
