### PR TITLE
Updating ui attributes when ui is redefined

### DIFF
--- a/extension/js/agent/marionette/serialize/serializeView.js
+++ b/extension/js/agent/marionette/serialize/serializeView.js
@@ -28,3 +28,5 @@ var serializeUI = function(ui) {
     }
   });
 }
+
+this.serializeUI = serializeUI;

--- a/extension/js/agent/patches/patchBackboneView.js
+++ b/extension/js/agent/patches/patchBackboneView.js
@@ -1,3 +1,12 @@
+this.patchViewUIChanges = function(view, prop, action, difference, oldValue) {
+  this.sendAppComponentReport("view:ui:change", {
+    cid: view.cid,
+    data: {
+      ui: this.serializeUI(view.ui)
+    }
+  })
+}
+
 var patchViewRemove = function(originalFunction) {
   return function() {
     var appComponent = this;
@@ -30,6 +39,14 @@ this.patchBackboneView = function(BackboneView) {
         // Patcha i metodi del componente dell'app
 
         patchAppComponentTrigger(view, 'view');
+
+        onDefined(view, 'ui', _.bind(function() {
+          // Call `patchViewUIChanges` when ui attributes change
+          onChange(view.ui, _.bind(this.patchViewUIChanges, this, view));
+          // Send a report about the UI change
+          this.patchViewUIChanges(view);
+        }, this));
+
         patchAppComponentEvents(view);
 
         // patchFunctionLater(view, "delegateEvents", function(originalFunction) { return function() {

--- a/extension/js/inspector/app/modules/UI.js
+++ b/extension/js/inspector/app/modules/UI.js
@@ -41,7 +41,8 @@ define([
     clientEvents: {
       'agent:search': 'onSearch',
       'agent:View:new': 'onViewNew',
-      'agent:View:remove': 'onViewRemove'
+      'agent:View:remove': 'onViewRemove',
+      'agent:view:ui:change': 'onViewUIChange'
     },
 
     regionTreeEvents: {
@@ -81,7 +82,7 @@ define([
 
     onViewRemove: function (event) {
       var cid = event.data.cid;
-      logger.log('ui', 'onViewRemove', cid);
+      logger.log('ui', 'could not find view');
 
       var view = this.viewCollection.findWhere({cid: cid});
       if (!view) {
@@ -90,6 +91,19 @@ define([
       }
 
       view.set('isRemoved', true)
+    },
+
+    onViewUIChange: function(event) {
+      var cid = event.cid;
+      logger.log('ui', 'onViewUIChange', cid);
+
+      var view = this.viewCollection.findWhere({ cid: cid });
+      if (!view) {
+        logger.log('ui', 'could not find view');
+        return;
+      }
+
+      view.set('ui', event.data.ui);
     },
 
 


### PR DESCRIPTION
This is a re-post of #60 on minor. 

The goal of the change is to make sure that UI elements stay uptodate in the inspector view panel ui pane. 

The primary problems @joshbedo and I had to overcome were 
a) UI is undefined at view onset
b) UI is set to an empty object, then an object w/ selectors, then an object w/ jquery objs, then updated on the fly. w/ each change we wanted to send the ui hash up to the inspector. 
