### PR TITLE
3 Data related changes

### DIFF
--- a/extension/css/inspector/main.scss
+++ b/extension/css/inspector/main.scss
@@ -20,14 +20,15 @@ body {
 [view="app-layout"],
 .app-layout-body,
 [data-region="tool"],
-[view="ui-layout"], [view="data-layout"], [view="radio-layout"], [view="activity-layout"]  {
+[view="ui-layout"], [view="data-layout"], [view="radio-layout"], [view="activity-layout"],
+ {
   height: inherit;
 }
 
 [data-region="view-tree"], [data-region="view-more-info"],
-[data-region="model-list"], [data-region="model-more-info"],
+.data-list, [data-region="info"],
 [data-region="channel-list"], [data-region="channel-info"],
-[data-region="activity-list"], [data-region="model-info"] {
+[data-region="activity-list"] {
   height: inherit;
   overflow-y: scroll;
 }

--- a/extension/js/agent/components/monitorAppComponentProperty.js
+++ b/extension/js/agent/components/monitorAppComponentProperty.js
@@ -19,7 +19,7 @@ var monitorAppComponentProperty = bind(function(appComponent, property, recursio
         // invia un report riguardante il cambiamento della proprietà
         var appComponentInfo = this.getAppComponentInfo(appComponent);
 
-        var reportName = appComponentInfo.category+":"+appComponentInfo.index+":change";
+        var reportName = appComponentInfo.category + ":property:change";
         sendAppComponentReport(reportName, {
             componentProperty: property,
             type: 'change'

--- a/extension/js/agent/patches/patchBackboneModel.js
+++ b/extension/js/agent/patches/patchBackboneModel.js
@@ -11,6 +11,17 @@ var patchModelDestroy = function(originalFunction) {
   }
 }
 
+this.patchModelAttributesChange = function(model, prop, action, difference, oldvalue) {
+  this.sendAppComponentReport("model:attributes:change", {
+    cid: model.cid,
+    data: {
+      serializedAttributes: this.serializeObject(model.attributes),
+      attributes: toJSON(model.attributes),
+      inspectedAttributes: this.inspectValue(model.attributes)
+    }
+  })
+}
+
 
 // @private
 this.patchBackboneModel = function(BackboneModel) {
@@ -29,6 +40,8 @@ this.patchBackboneModel = function(BackboneModel) {
         // monitorAppComponentProperty(model, "cid", 0);
         // monitorAppComponentProperty(model, "urlRoot", 0); // usato dal metodo url() (insieme a collection)
         // monitorAppComponentProperty(model, "collection", 0);
+
+        onChange(model.attributes, _.bind(this.patchModelAttributesChange, this, model))
 
         // Patcha i metodi del componente dell'app
         patchAppComponentTrigger(model);

--- a/extension/js/agent/watchers/onChange.js
+++ b/extension/js/agent/watchers/onChange.js
@@ -2,7 +2,7 @@ var onChange = function(object, callback) {
   callback = _.bind(callback, this)
 
   var _onChange = function(prop, action, difference, oldvalue) {
-    if (!_.isEmpty(difference.added)) {
+    if (difference && !_.isEmpty(difference.added)) {
       unwatch(this, difference.added, _onChange);
     }
 

--- a/extension/js/inspector/app/modules/Data.js
+++ b/extension/js/inspector/app/modules/Data.js
@@ -16,6 +16,7 @@ define([
       'agent:Model:new': 'onModelNew',
       'agent:Model:destroy': 'onModelDestroy',
       'agent:Collection:new': 'onCollectionNew',
+      'agent:model:attributes:change': 'onModelAttributesChange'
     },
 
     initialize: function() {
@@ -25,6 +26,9 @@ define([
       this.client = client;
       this.modelCollection = new ModelCollection();
       this.collectionCollection = new CollectionCollection();
+
+      this.modelGraveyard = new ModelCollection();
+      this.collectionGraveyard = new CollectionCollection();
     },
 
     setupEvents: function() {
@@ -57,7 +61,18 @@ define([
         return;
       }
 
-      model.set('isDestroyed', true)
+      model.set('isDestroyed', true);
+      this.modelCollection.remove(model);
+      this.modelGraveyard.add(model);
+    },
+
+    onModelAttributesChange: function(event) {
+      var model = this.modelCollection.findModel(event.cid);
+      if (!model) {
+        return;
+      }
+
+      model.set(event.data);
     },
 
     startModule: function() {

--- a/extension/js/inspector/app/modules/Data/models/ModelCollection.js
+++ b/extension/js/inspector/app/modules/Data/models/ModelCollection.js
@@ -4,7 +4,12 @@ define([
 ], function(Backbone, ModelModel) {
 
   return Backbone.Collection.extend({
-    model: ModelModel
+    model: ModelModel,
+
+    findModel: function(cid) {
+      return this.findWhere({cid: cid});
+    }
+
   });
 
 })

--- a/extension/js/inspector/app/modules/Data/views/ModelInfo.js
+++ b/extension/js/inspector/app/modules/Data/views/ModelInfo.js
@@ -15,6 +15,10 @@ define([
       }
     },
 
+    modelEvents: {
+      'change': 'render'
+    },
+
     serializeData: function() {
       var data = {};
       _.extend(data, this.serializeModel(this.model));

--- a/extension/js/inspector/app/modules/Data/views/ModelRow.js
+++ b/extension/js/inspector/app/modules/Data/views/ModelRow.js
@@ -18,6 +18,10 @@ define([
       "click @ui.moreInfoLink": "onClickInfo"
     },
 
+    modelEvents: {
+      'change': 'render'
+    },
+
     onClickInfo: function() {
       this.highlightRow();
 

--- a/extension/templates/devTools/data/layout.html
+++ b/extension/templates/devTools/data/layout.html
@@ -1,5 +1,5 @@
 
-<div class="col-xs-5">
+<div class="data-list col-xs-5">
   <ul class="nav nav-tabs">
     <li role="presentation" class="{{#if active_nav.is_model}}active{{/if}}">
       <a data-nav="model" href="#">Models</a>


### PR DESCRIPTION
Three things are going on here:
1. we're tweaking the css for the data pane to keep the panes scrolling (it's stupid)
2. we're adding a `patchModelAttributesChange` method for observing attribute changes
3. we add the idea of a `modelGraveyard` where models go when they're destroyed. Importantly models are removed from the data pane when they're no longer active. 
