### PR TITLE
When patching the define callback, maintain the arity of the callback

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,7 +62,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('build', ['agent', 'sass']);
 
-  grunt.registerTask('test', ['mocha']);
+  grunt.registerTask('test', ['agent', 'mocha']);
 
   grunt.registerTask('default', ['watch']);
 

--- a/extension/js/agent/agent.js
+++ b/extension/js/agent/agent.js
@@ -3,7 +3,7 @@
 
 debug.log("Backbone agent is starting...");
 
-patchDefine(
+this.patchDefine(
   _.bind(this.patchBackbone, this),
   _.bind(this.patchMarionette, this)
 );

--- a/extension/js/agent/build/core.js
+++ b/extension/js/agent/build/core.js
@@ -79,6 +79,7 @@
 // @include ../patches/util/patchFunction.js
 // @include ../patches/util/patchFunctionLater.js
 
+// @include ../patches/patchDefineCallback.js
 // @include ../patches/patchDefine.js
 // @include ../patches/patchBackbone.js
 // @include ../patches/patchBackboneComponent.js

--- a/extension/js/agent/patches/patchDefine.js
+++ b/extension/js/agent/patches/patchDefine.js
@@ -6,73 +6,76 @@ var moduleHasComponents = function (Candidate, components) {
 };
 
 var isBackbone = function(Candidate) {
-    return moduleHasComponents(Candidate, ['View', 'Model', 'Collection', 'Router']);
-}
+  return moduleHasComponents(Candidate, ['View', 'Model', 'Collection', 'Router']);
+};
 
 var isMarionette = function(Candidate) {
-    return moduleHasComponents(Candidate, [
-        'View', 'ItemView', 'CollectionView',
-        'CompositeView', 'Region', 'RegionManager',
-        'Application', 'Module'
-    ]);
-}
+  return moduleHasComponents(Candidate, [
+    'View', 'ItemView', 'CollectionView',
+    'CompositeView', 'Region', 'RegionManager',
+    'Application', 'Module'
+  ]);
+};
 
 // @private
 // Calls the callback passing to it the Backbone object every time it's detected.
 // The function uses multiple methods of detection.
-var patchDefine = function(patchBackbone, patchMarionette) {
-    var loadedModules = {};
-    debug.log('patch define');
+this.patchDefine = function(patchBackbone, patchMarionette) {
+  var agent = this;
+  var loadedModules = {};
+  debug.log('patch define');
 
-    // AMD
-    patchFunctionLater(window, "define", function(originalFunction) {
-      return function() {
-        // debug.log('patched define');
-        // function arguments: (id? : String, dependencies? : Array, factory : Function)
+  // AMD
+  patchFunctionLater(window, "define", function(originalFunction) {
+    return function() {
+      // function arguments: (id? : String, dependencies? : Array, factory : Function)
 
-        // make arguments editable
-        var argumentsArray = Array.prototype.slice.call(arguments);
-        // find the factory function to patch it
-        for (var i=0,l=argumentsArray.length; i<l; i++) {
-            if (typeof argumentsArray[i] == "function") {
-                // factory function found, patch it.
-                // NOTE: in the patcher function, specify the parameters for the
-                // default modules, or in case of a module with no dependencies but
-                // that uses the default modules internally, the original define would see a 0-arity
-                // function and would call it without them (see define() in the AMD API)
-                patchFunction(argumentsArray, i, function(originalFunction) {
-                  return function(require, exports, modules) {
-                    // debug.log('patched argument...');
-                    var module = originalFunction.apply(this, arguments);
+      // make arguments editable
+      var argumentsArray = Array.prototype.slice.call(arguments);
+      // find the factory function to patch it
+      for (var i=0,l=argumentsArray.length; i<l; i++) {
+        if (typeof argumentsArray[i] == "function") {
+          // factory function found, patch it.
+          // NOTE: in the patcher function, specify the parameters for the
+          // default modules, or in case of a module with no dependencies but
+          // that uses the default modules internally, the original define would see a 0-arity
+          // function and would call it without them (see define() in the AMD API)
+          patchFunction(argumentsArray, i, function(originalFunction) {
+            var functionBody = function (bodyArguments) {
+              // debug.log('patched argument...');
+              var module = originalFunction.apply(this, bodyArguments);
 
-                    // check if Backbone has been defined by the factory fuction
-                    // (some factories set "this" to Backbone)
-                    var Candidate = module || this;
+              // check if Backbone has been defined by the factory fuction
+              // (some factories set "this" to Backbone)
+              var Candidate = module || this;
 
-                    if (isBackbone(Candidate)) {
-                      debug.log('Backbone define detected');
-                      loadedModules.Backbone = Candidate;
-                      patchBackbone(Candidate);
+              if (!loadedModules.Backbone && isBackbone(Candidate)) {
+                debug.log('Backbone define detected');
+                loadedModules.Backbone = Candidate;
+                patchBackbone(Candidate);
 
-                      if (isMarionette(Candidate.Marionette)) {
-                        debug.log('Marionette define detected');
-                        loadedModules.Marionette = Candidate.Marionette;
-                        patchMarionette(loadedModules.Backbone, loadedModules.Marionette);
-                      }
-                    }
+                if (isMarionette(Candidate.Marionette)) {
+                  debug.log('Marionette define detected');
+                  loadedModules.Marionette = Candidate.Marionette;
+                  patchMarionette(loadedModules.Backbone, loadedModules.Marionette);
+                }
+              }
 
-                    if (isMarionette(Candidate))  {
-                      debug.log('Marionette define detected');
-                      loadedModules.Marionette = Candidate;
-                      patchMarionette(loadedModules.Backbone, loadedModules.Marionette);
-                    }
+              if (!loadedModules.Marionette && isMarionette(Candidate)) {
+                debug.log('Marionette define detected');
+                loadedModules.Marionette = Candidate;
+                patchMarionette(loadedModules.Backbone, loadedModules.Marionette);
+              }
 
-                    return module;
-                }});
+              return module;
+            };
 
-                break;
-            }
+            return agent.patchDefineCallback(argumentsArray[i], functionBody);
+          });
+
+          break;
         }
-        return originalFunction.apply(this, argumentsArray);
+      }
+      return originalFunction.apply(this, argumentsArray);
     }});
 };

--- a/extension/js/agent/patches/patchDefineCallback.js
+++ b/extension/js/agent/patches/patchDefineCallback.js
@@ -1,0 +1,19 @@
+// A globally-accessible object for holding callbacks for patched function access
+this.defineCallbacks = {};
+
+// RequireJS uses the function's arity to determine how to handle dependencies
+// We need to make sure that the function we return maintains the arity of the original function
+// Even though we don't use these arguments, we need to capture them to maintain arity
+this.patchDefineCallback = function (originalCallback, newCallback) {
+  var callId = _.uniqueId("defineCall");
+  this.defineCallbacks[callId] = {
+    newCallback: newCallback
+  };
+
+  var params = _.times(originalCallback.length, function(i) { return "a" + i; });
+  return Function.apply({}, params.concat("" +
+    "var newCallback = window.__agent.defineCallbacks." + callId + ".newCallback;" +
+    "delete window.__agent.defineCallbacks." + callId + ";" +
+    "return newCallback.call(this, Array.prototype.slice.call(arguments));"
+  ));
+};

--- a/extension/js/test/unit/AgentSpecRunner.html
+++ b/extension/js/test/unit/AgentSpecRunner.html
@@ -91,6 +91,7 @@
     <script src="agent/marionette/serialize/serializeView.spec.js"></script>
     <script src="agent/marionette/serialize/serializeModel.spec.js"></script>
     <script src="agent/utils/inspectValue.spec.js"></script>
+    <script src="agent/patches/patchDefineCallback.spec.js"></script>
     <script src="agent/creating-a-model.spec.js"></script>
 
   </head>

--- a/extension/js/test/unit/agent/patches/patchDefineCallback.spec.js
+++ b/extension/js/test/unit/agent/patches/patchDefineCallback.spec.js
@@ -1,0 +1,41 @@
+describe("patchDefineCallback", function () {
+  beforeEach(function () {
+    window.defineCallbacks = {};
+    window.__agent = { defineCallbacks: window.defineCallbacks };
+
+    this.originalCallback = function (a0, a1, a2, a3, a4) {};
+    this.module = { myModule: true };
+    this.newCallback = this.sinon.stub().returns(this.module);
+    this.patchedCallback = window.patchDefineCallback(this.originalCallback, this.newCallback);
+  });
+
+  it("returns a function with the same arity as the original callback", function () {
+    expect(this.patchedCallback).to.have.length(5);
+  });
+
+  it("adds a defineCallback to the global", function () {
+    expect(_.keys(window.defineCallbacks)).to.have.length(1);
+  });
+
+  describe("calling the patchedCallback", function () {
+    beforeEach(function () {
+      this.context = {};
+      this.callbackArgs = ['a0', 'a1', 'a2', 'a3', 'a4'];
+      this.returnedModule = this.patchedCallback.apply(this.context, this.callbackArgs);
+    });
+
+    it("calls the newCallback with the same arguments", function () {
+      expect(this.newCallback).to.have.been.calledOnce
+        .and.calledOn(this.context)
+        .and.calledWithMatch(this.callbackArgs);
+    });
+
+    it("returns the result of newCallback", function () {
+      expect(this.returnedModule).to.equal(this.module);
+    });
+
+    it("removes the defineCallback from the global", function () {
+      expect(_.keys(window.defineCallbacks)).to.be.empty;
+    });
+  });
+});


### PR DESCRIPTION
This lets patchDefine work with modules like backbone.projections that
manage their own dependencies in a require-like fashion.

Formatting auto-triggered, making this commit a bit noisy.
