### PR TITLE
[inspector] add view pane to view info panel

### DIFF
--- a/extension/js/agent/marionette/serialize/serializeView.js
+++ b/extension/js/agent/marionette/serialize/serializeView.js
@@ -16,6 +16,9 @@ this.serializeView = function(view) {
   data.modelEvents = serializeEventsHash(view.modelEvents);
   data.collectionEvents = serializeEventsHash(view.collectionEvents);
   data.properties = this.serializeObjectProperties(view);
+  data._requirePath = view._requirePath;
+  data._className = view._className;
+  data.parentClass = this.isKnownType(view) ? this.knownType(view).name : '';
 
   return data;
 }

--- a/extension/js/inspector/app/modules/UI/views/ViewMoreInfo.js
+++ b/extension/js/inspector/app/modules/UI/views/ViewMoreInfo.js
@@ -118,7 +118,6 @@ define([
           handler = _event.eventHandler;
         }
 
-
         var eventName = (!!this.objName) ? (this.objName + " " + _event.eventName) : _event.eventName;
 
         return {
@@ -130,10 +129,35 @@ define([
       return data;
     },
 
-
-
     serializeData: function() {
-      var data = this.serializeModel(this.model);
+      var infoItems = ['cid', 'model', 'collection', 'parentClass'];
+      var data = {};
+      _.extend(data, this.serializeModel(this.model));
+
+      data.info = _.pick(data.properties, infoItems);
+      if (data._requirePath) {
+        data.info._requirePath = {
+          name: 'path',
+          value: data._requirePath
+        }
+
+        data.info._className = {
+          name: 'class',
+          value: data._className
+        }
+      }
+
+      if (data.parentClass) {
+        data.info.parentClass = {
+          name: 'parentClass',
+          value: data.parentClass
+        };
+      }
+
+      data.properties = _.omit(data.properties, infoItems,
+        'options', '_events', 'events', 'ui', 'modelEvents', 'collectionEvents', 'el', '$el');
+
+      data.element = formatEL(data.element);
       data.events = this.presentEvents(this.model);
       data.ui = this.presentUI(this.model.get('ui'));
       return data;

--- a/extension/js/inspector/app/modules/UI/views/ViewTree.js
+++ b/extension/js/inspector/app/modules/UI/views/ViewTree.js
@@ -126,6 +126,15 @@ define([
       Radio.command('ui', 'highlight-view', {
         viewPath: this.model.get('path'),
       });
+    },
+
+    serializeData: function() {
+      var data = Tree.prototype.serializeData.apply(this, arguments);
+
+      data.summary = (this.viewModel && this.viewModel.get('_className')) ||
+       this.model.get('name');
+
+      return data;
     }
 
   });

--- a/extension/templates/devTools/ui/moreInfo.html
+++ b/extension/templates/devTools/ui/moreInfo.html
@@ -1,6 +1,33 @@
 <div class="sidebar-pane-stack flex-auto visible">
 
   <div class="sidebar-pane-title expanded" tabindex="0">
+    View
+  </div>
+  <div class="sidebar-pane visible">
+    <div class="body">
+      <div class="section expanded">
+        <ol class="properties properties-tree monospace">
+          {{#each info}}
+          <li data-property-key="options" data-property-name="{{name}}" title="" style="">
+            <span class="name">{{name}}</span><span class="separator">: </span>
+            <span class="value console-formatted-undefined" title="undefined"> {{value}} </span>
+          </li>
+          {{/each}}
+          <li title="" style="">
+            <span class="name">$el</span><span class="separator">: </span>
+            <span class="value console-formatted-undefined" title="undefined"> [{{{element}}}] </span>
+          </li>
+          <li title="" style="">
+            <span class="name">el</span><span class="separator">: </span>
+            <span class="value console-formatted-undefined" title="undefined"> {{{element}}} </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
+
+
+  <div class="sidebar-pane-title expanded" tabindex="0">
     Options
   </div>
   <div class="sidebar-pane visible">

--- a/extension/templates/devTools/ui/tree.html
+++ b/extension/templates/devTools/ui/tree.html
@@ -6,7 +6,7 @@
     <span style="width:19px; display: inline-block;"></span>
   {{/if}}
 
-  <a data-action='more-info' href="#"> {{ name }}</a>
+  <a data-action='more-info' href="#"> {{ summary }}</a>
 
   <span
 


### PR DESCRIPTION
This PR introduces the "view" pane in the UI info panel. The view pane shows the cid, el, model, and collections. Also if the view has a _requirePath or _className field set, it'll use that for a class and path field.

Another nice win, here is that we get to take a lot of shit out of the properties pane that is now redundant.

![](http://f.cl.ly/items/1N012y2R0W0m173e3Z2c/Image%202014-11-22%20at%209.07.33%20PM.png)
