### PR TITLE
[inspector] Make more objects clickable

### DIFF
--- a/extension/js/agent/marionette/knownTypes.js
+++ b/extension/js/agent/marionette/knownTypes.js
@@ -104,8 +104,8 @@ this.knownTypes = function() {
     'Marionette.Application': {
       type: this.patchedMarionette.Application,
       name: 'marionette-application',
-      cid: function(obj) { return obj.cid },
-      toString: function(obj) {return '<Marionette.Application '+obj.cid+'>'}
+      cid: function(obj) { return undefined },
+      toString: function(obj) {return '<Marionette.Application>'}
     },
 
     'Marionette.Module': {
@@ -120,6 +120,13 @@ this.knownTypes = function() {
       name: 'marionette-controller',
       cid: function(obj) { return undefined },
       toString: function(obj) {return '<Marionette.Controller>'}
+    },
+
+    'Marionette.Region': {
+      type: this.patchedMarionette.Region,
+      name: 'marionette-region',
+      cid: function(obj) { return undefined },
+      toString: function(obj) {return '<Marionette.Region>'}
     },
 
     'Backbone.View': {

--- a/extension/js/inspector/app.js
+++ b/extension/js/inspector/app.js
@@ -7,9 +7,10 @@ define([
   'util/ModuleRoutes',
   'client',
   'app/views/Layout',
+  'util/isViewType'
 ], function(
   Backbone, Marionette, Radio, logger, Router, moduleRoutes,
-  client, Layout) {
+  client, Layout, isViewType) {
 
   return Marionette.Application.extend({
 
@@ -152,8 +153,11 @@ define([
         return;
       }
 
-      if (object.name == "model") {
+      if (object.type == "type-backbone-model") {
         var url = 'data/models/'+object.cid;
+        this.navigate(url);
+      } else if (isViewType(object)) {
+        var url = 'data/views/'+object.cid;
         this.navigate(url);
       }
 

--- a/extension/js/inspector/app/behaviors/ClickableProperties.js
+++ b/extension/js/inspector/app/behaviors/ClickableProperties.js
@@ -1,0 +1,93 @@
+define([
+  'marionette',
+  'util/Radio'
+], function(Marionette, Radio) {
+
+  return Marionette.Behavior.extend({
+    ui: {
+      property: '[data-property-name]',
+      propertyContext: '[data-property-value-context]',
+      propertyCallback: '[data-property-value-callback]'
+    },
+
+    events: {
+      'click @ui.property': 'onClickProperty',
+      'click @ui.propertyContext': 'onClickContext',
+      'click @ui.propertyCallback': 'onClickCallback'
+    },
+
+    onClickContext: function(e) {
+      e.stopPropagation();
+      var property = this._indexedProperty($(e.currentTarget));
+      var object = property.context;
+
+      if (object && object.type && object.cid) {
+        Radio.command('app', 'navigate:knownObject', {
+          object: object
+        })
+      }
+    },
+
+    onClickCallback: function(e) {
+      e.stopPropagation();
+      var property = this._indexedProperty($(e.currentTarget));
+
+      var object = property.callback;
+      // if (object && object.type && object.cid) {
+      //   Radio.command('app', 'navigate:knownObject', {
+      //     object: object
+      //   })
+      // }
+    },
+
+    onClickProperty: function(e) {
+      e.stopPropagation();
+
+      var $target = $(e.currentTarget);
+      var propertyKey = $target.data('property-key') || $target.closest('ol').data('property-key');
+      var propertyName = $target.data('property-name');
+
+      if (propertyKey) {
+        var property = this.view.model.get(propertyKey);
+        if (!property) {
+          return
+        }
+
+        var object = property[propertyName]
+      } else {
+
+        // this is the case where we're looking directly on the instance
+        // in the properties.
+        var properties = this.view.model.get('properties');
+        var object = properties[propertyName];
+      }
+
+
+      if (object && object.type && object.cid) {
+        Radio.command('app', 'navigate:knownObject', {
+          object: object
+        })
+      }
+    },
+
+    _indexedProperty: function($target) {
+      var propertyKey = $target.data('property-key') || $target.closest('ol').data('property-key');
+      var propertyIndex = $target.closest('li').data('property-index');
+
+
+      var properties = this.view.model.get(propertyKey);
+      if (!properties) {
+        return
+      }
+
+      var property = properties[propertyIndex]
+      if (!property) {
+        return
+      }
+
+      return property;
+    }
+
+  });
+
+});

--- a/extension/js/inspector/app/modules/Data/views/ModelInfo.js
+++ b/extension/js/inspector/app/modules/Data/views/ModelInfo.js
@@ -2,8 +2,9 @@ define([
   'marionette',
   'util/Radio',
   "text!templates/devTools/data/info.html",
-  'app/behaviors/SidebarPanes'
-], function(Marionette, Radio, tpl, SidebarPanesBehavior) {
+  'app/behaviors/SidebarPanes',
+  'app/behaviors/ClickableProperties'
+], function(Marionette, Radio, tpl, SidebarPanesBehavior, ClickableProperties) {
 
   return Marionette.ItemView.extend({
 
@@ -12,6 +13,9 @@ define([
     behaviors: {
       sidebarPanes: {
         behaviorClass: SidebarPanesBehavior,
+      },
+      clickableProperties: {
+        behaviorClass: ClickableProperties
       }
     },
 

--- a/extension/js/inspector/app/modules/UI.js
+++ b/extension/js/inspector/app/modules/UI.js
@@ -221,6 +221,15 @@ define([
         this.startModule();
         this.showModule();
         this.fetchData();
+      },
+      showView: function(cid) {
+        this.showModule();
+        var view = this.viewCollection.findView(cid);
+        Radio.command('ui', 'show:more-info', {
+          cid: cid,
+          path: view.treeProperties.path
+        });
+
       }
     }
   });

--- a/extension/js/inspector/app/modules/UI/views/Layout.js
+++ b/extension/js/inspector/app/modules/UI/views/Layout.js
@@ -69,6 +69,7 @@ define([
         return;
       }
 
+      this.highlightRow(data);
       this.getRegion('viewMoreInfo').show(new ViewMoreInfo({
         model: viewModel,
         path: data.path

--- a/extension/js/inspector/app/modules/UI/views/ViewMoreInfo.js
+++ b/extension/js/inspector/app/modules/UI/views/ViewMoreInfo.js
@@ -3,8 +3,9 @@ define([
   'util/Radio',
   "text!templates/devTools/ui/moreInfo.html",
   'app/behaviors/SidebarPanes',
-  'util/presenters/formatEL'
-], function(Marionette, Radio, tpl, SidebarPanesBehavior, formatEL) {
+  'util/presenters/formatEL',
+  'app/behaviors/ClickableProperties'
+], function(Marionette, Radio, tpl, SidebarPanesBehavior, formatEL, ClickableProperties) {
 
   return Marionette.ItemView.extend({
     template: tpl,
@@ -12,38 +13,20 @@ define([
     events: {
       'click @ui.uiElement': 'onClickUIElement',
       'click @ui.eventHandler': 'onClickEventHandler',
-      'click @ui.property': 'onClickProperty'
     },
 
     ui: {
       uiElement: '[data-ui-elem]',
       eventHandler: '[data-event]',
-      property: '[data-property-name]'
     },
 
     behaviors: {
       sidebarPanes: {
         behaviorClass: SidebarPanesBehavior,
-      }
-    },
+      },
 
-    onClickProperty: function(e) {
-      e.stopPropagation();
-
-      var $target = $(e.currentTarget);
-      var propertyKey = $target.data('property-key');
-      var propertyName = $target.data('property-name');
-
-      var property = this.model.get(propertyKey);
-      if (!property) {
-        return
-      }
-
-      var object = property[propertyName]
-      if (object.type && object.cid) {
-        Radio.command('app', 'navigate:knownObject', {
-          object: object
-        })
+      clickableProperties: {
+        behaviorClass: ClickableProperties
       }
     },
 
@@ -160,6 +143,7 @@ define([
       data.element = formatEL(data.element);
       data.events = this.presentEvents(this.model);
       data.ui = this.presentUI(this.model.get('ui'));
+      data.option_key = "options";
       return data;
     }
   });

--- a/extension/js/inspector/app/modules/UI/views/ViewTree.js
+++ b/extension/js/inspector/app/modules/UI/views/ViewTree.js
@@ -61,7 +61,6 @@ define([
       }
 
       this.showMoreInfo();
-      this.highlightRow();
 
       return false;
     },
@@ -95,7 +94,7 @@ define([
 
     highlightRow: function() {
       this.unhighlightRow();
-      this.ui.view.addClass('is-highlighted');
+      this.ui.view.addClass && this.ui.view.addClass('is-highlighted');
     },
 
     unhighlightRow: function() {

--- a/extension/js/inspector/main.js
+++ b/extension/js/inspector/main.js
@@ -64,7 +64,11 @@ require([
   "app/modules/UI",
   "app/modules/Data",
   "app/modules/Activity",
-], function($, treeGrid, Handlebars, Marionette, logger, App, RadioApp, UIApp, DataApp, ActivityApp) {
+  "text!templates/devTools/partials/_property.html"
+], function(
+    $, treeGrid, Handlebars, Marionette,
+    logger, App, RadioApp, UIApp, DataApp, ActivityApp,
+    _property) {
 
     Marionette.Renderer.render = function(template, data, view) {
       return Handlebars.compile(template)(data);
@@ -73,6 +77,8 @@ require([
     $(document).ready(function() {
         // var router = new Router();
         // Backbone.history.start();
+
+        Handlebars.registerPartial('templates/devTools/partials/_property.html', _property);
 
         window.app = new App();
         app.start();

--- a/extension/js/inspector/util/ModuleRoutes.js
+++ b/extension/js/inspector/util/ModuleRoutes.js
@@ -2,6 +2,7 @@ define([], function() {
   return [
     ['radio(/)',      ['Radio', 'index']],
     ['ui(/)',         ['UI', 'index']],
+    ['data/views/:cid(/)', ['UI', 'showView']],
     ['data(/)',       ['Data', 'index']],
     ['data/models/:cid(/)', ['Data', 'showModel']],
     ['activity(/)',   ['Activity', 'index']],

--- a/extension/js/inspector/util/isViewType.js
+++ b/extension/js/inspector/util/isViewType.js
@@ -1,0 +1,9 @@
+define([], function() {
+  return function(object) {
+    return _.contains([
+        "type-backbone-view", "type-marionette-item-view",
+        "type-marionette-layout-view", "type-marionette-layout",
+        "type-marionette-collection-view","type-marionette-composite-view"
+      ], object.type)
+  }
+});

--- a/extension/js/lib/handlebars.js
+++ b/extension/js/lib/handlebars.js
@@ -593,7 +593,9 @@ var __module6__ = (function(__dependency1__, __dependency2__, __dependency3__) {
     return prog;
   }
 
-  __exports__.program = program;function invokePartial(partial, name, context, helpers, partials, data, depths) {
+  __exports__.program = program;
+
+  function invokePartial(partial, name, context, helpers, partials, data, depths) {
     var options = { partial: true, helpers: helpers, partials: partials, data: data, depths: depths };
 
     if(partial === undefined) {

--- a/extension/templates/devTools/data/info.html
+++ b/extension/templates/devTools/data/info.html
@@ -6,12 +6,9 @@
   <div class="sidebar-pane visible">
     <div class="body">
       <div class="section expanded">
-        <ol class="properties properties-tree monospace">
+        <ol data-property-key="" class="properties properties-tree monospace">
           {{#each info}}
-          <li title="" style="">
-            <span class="name">{{name}}</span><span class="separator">: </span>
-            <span class="value console-formatted-undefined" title="undefined"> {{value}} </span>
-          </li>
+            {{> templates/devTools/partials/_property.html this}}
           {{/each}}
         </ol>
       </div>
@@ -25,14 +22,22 @@
   <div class="sidebar-pane visible">
     <div class="body">
       <div class="section expanded">
-        <ol class="properties properties-tree monospace">
+        <ol data-property-key="_events" class="properties properties-tree monospace">
           {{#each _events}}
-          <li title="" style="">
+          <li data-property-index="{{@index}}">
             <span class="name">{{eventName}}</span><span class="separator">: </span>
             <span class="value console-formatted-undefined" title="undefined">
 
-            {{context.inspect}} {{#if callback.key}} {{callback.key}} {{else}} {{callback.inspect}} {{/if}}
+              <span data-property-value-context>
+              {{context.inspect}}</span>
 
+              <span data-property-value-callback>
+                {{#if callback.key}}
+                  {{callback.key}}
+                {{else}}
+                  {{callback.inspect}}
+                {{/if}}
+              </span>
             </span>
           </li>
           {{/each}}
@@ -109,10 +114,7 @@
       <div class="section expanded">
         <ol class="properties properties-tree monospace">
           {{#each properties}}
-          <li title="" style="">
-            <span class="name">{{name}}</span><span class="separator">: </span>
-            <span class="value console-formatted-undefined" title="undefined"> {{value}} </span>
-          </li>
+            {{> templates/devTools/partials/_property.html this}}
           {{/each}}
         </ol>
       </div>

--- a/extension/templates/devTools/partials/_property.html
+++ b/extension/templates/devTools/partials/_property.html
@@ -1,0 +1,4 @@
+<li data-property-name="{{name}}" title="" style="">
+  <span class="name">{{name}}</span><span class="separator">: </span>
+  <span class="value console-formatted-undefined" title="undefined"> {{value}} </span>
+</li>

--- a/extension/templates/devTools/ui/moreInfo.html
+++ b/extension/templates/devTools/ui/moreInfo.html
@@ -33,12 +33,9 @@
   <div class="sidebar-pane visible">
     <div class="body">
       <div class="section expanded">
-        <ol class="properties properties-tree monospace">
+        <ol data-property-key="options" class="properties properties-tree monospace">
           {{#each options}}
-          <li data-property-key="options" data-property-name="{{name}}" title="" style="">
-            <span class="name">{{name}}</span><span class="separator">: </span>
-            <span class="value console-formatted-undefined" title="undefined"> {{value}} </span>
-          </li>
+            {{> templates/devTools/partials/_property.html this}}
           {{/each}}
         </ol>
       </div>
@@ -113,12 +110,9 @@
   <div class="sidebar-pane visible">
     <div class="body">
       <div class="section expanded">
-        <ol class="properties properties-tree monospace">
+        <ol data-property-key="" class="properties properties-tree monospace">
           {{#each properties}}
-          <li title="">
-            <span class="name">{{name}}</span><span class="separator">: </span>
-            <span class="value console-formatted-undefined" title="undefined">{{value}}</span>
-          </li>
+            {{> templates/devTools/partials/_property.html this}}
           {{/each}}
         </ol>
       </div>


### PR DESCRIPTION
This does a ton of stuff to make things more clickable. We now support clicking in these places:

UI: view, options, events, properties
Model: model, listeners, properties

and you can click on views and models.

---

I left a spot for clicking on functions that will show up in the source panel, but did not complete that because I ran out of time. I might be able to circle back and get that in before this gets in.  

Tasks:
- extract ClickbableProperties Behavior
- share _property partial among views and models
- handle clicking on properties as well os options
- handle navigating to a view
- handle indexed properties like context and callback
