### PR TITLE
Add Lazy Worker

### DIFF
--- a/extension/js/agent/agent.js
+++ b/extension/js/agent/agent.js
@@ -22,13 +22,13 @@ this.start = function(Backbone, Marionette) {
   this.patchMarionette(Backbone, Marionette);
 };
 
+this.lazyWorker = new this.LazyWorker();
 
 console.log('Marionette Inspector: window.__agent = ', this);
 sendAppComponentReport('start');
 
 
 window.setTimeout(function() {
-
   if(window.__agent && window.__agent.patchedBackbone) {
     return;
   }

--- a/extension/js/agent/build/core.js
+++ b/extension/js/agent/build/core.js
@@ -57,6 +57,8 @@ var Marionette = this.Marionette;
 // @include ../utils/unwrapListenToOnceWrapper.js
 // @include ../utils/isNativeFunction.js
 // @include ../utils/printProperty.js
+// @include ../utils/lazyWorker.js
+// @include ../utils/stackFrame.js
 
 
 

--- a/extension/js/agent/components/AppComponentAction.js
+++ b/extension/js/agent/components/AppComponentAction.js
@@ -18,3 +18,5 @@ var AppComponentAction = function(type, name, data, dataKind) {
     this.printDetailsInConsole = function() {
     };
 };
+
+this.AppComponentAction = AppComponentAction;

--- a/extension/js/agent/components/addAppComponentAction.js
+++ b/extension/js/agent/components/addAppComponentAction.js
@@ -28,3 +28,5 @@ var addAppComponentAction = bind(function(appComponent, appComponentAction) {
 
     return actionIndex;
 }, this);
+
+this.addAppComponentAction = addAppComponentAction;

--- a/extension/js/agent/components/registerAppComponent.js
+++ b/extension/js/agent/components/registerAppComponent.js
@@ -34,3 +34,5 @@ var registerAppComponent = bind(function(appComponentCategory, appComponent, com
 
     return appComponentIndex;
 }, this);
+
+this.registerAppComponent = registerAppComponent;

--- a/extension/js/agent/marionette/serialize/serializeView.js
+++ b/extension/js/agent/marionette/serialize/serializeView.js
@@ -1,3 +1,25 @@
+this.serializeEmptyView = function(view) {
+  var data = {};
+
+  data.cid = view.cid;
+  data.isLoading = true;
+  data.options = {};
+  data.ui = {};
+  data.el = {};
+  data.events = {};
+  data._events = {};
+  data.modelEvents = {};
+  data.collectionEvents = {};
+  data.triggers = {};
+  data.properties = {};
+  data.ancestorInfo = {};
+  data._requirePath = '';
+  data._className = '';
+  data.parentClass = '';
+
+  return data;
+};
+
 this.serializeView = function(view) {
   var data = {};
   // debug.log('serializeView', view)
@@ -8,6 +30,7 @@ this.serializeView = function(view) {
 
 
   data.cid = view.cid;
+  data.isLoading = false; // set when a view is registered, but not serialized
 
   data.options = this.serializeObject(view.options);
   data.ui = this.serializeUI(view.ui);

--- a/extension/js/agent/patches/patchAppComponentTrigger.js
+++ b/extension/js/agent/patches/patchAppComponentTrigger.js
@@ -18,50 +18,63 @@ _.extend(this, {
 
     _incActionId: _.debounce(function () {
         this.actionId++;
-    }, 50)
+    }, 1000)
 });
+
+var serializeTrigger = function(
+  agent, args, start, end, depth,
+  ctx, eventName) {
+
+  // Convert backbone array of array of backbone listener to a flattened array of
+  // inspector listener with event trigger merged in.
+  var events = _.pick((ctx._events || {}), 'all', eventName);
+  var listeners = agent.serializeEvents(events);
+
+  // save data only if there is
+  var data = {
+    eventId: agent.getEventId(),
+    actionId: agent.getActionId(),
+    startTime: start,
+    endTime: end,
+    eventName: eventName,
+    args: _.map(args, agent.inspectValue, agent),
+    depth: depth,
+    context: agent.inspectValue(ctx),
+    listeners: listeners
+  };
+
+  var dataKind = (data === undefined) ? undefined : "event arguments";
+
+  agent.addAppComponentAction(ctx, new agent.AppComponentAction(
+    "trigger", eventName, data, dataKind
+  ));
+}
 
 var patchAppComponentTrigger = bind(function(appComponent, eventType) {//
 
-    var agent = this;
-    patchFunctionLater(appComponent, "trigger", function(originalFunction) {
-      return function(eventName) {
+  var agent = this;
+  patchFunctionLater(appComponent, "trigger", function(originalFunction) {
+    return function(eventName) {
 
-        agent.depth++;
-        var start = Date.now();
-        var result = originalFunction.apply(this, arguments);
-        var end = Date.now();
+      agent.depth++;
+      var start = Date.now();
+      var result = originalFunction.apply(this, arguments);
+      var end = Date.now();
 
-        // function signature: trigger(eventName, arg1, arg2, ...)
-        var args  = _.rest(arguments);
-        var context = this;
+      // function signature: trigger(eventName, arg1, arg2, ...)
+      var args  = _.rest(arguments);
+      var context = this;
 
-        // Convert backbone array of array of backbone listener to a flattened array of
-        // inspector listener with event trigger merged in.
-        var events = _.pick((this._events || {}), 'all', eventName);
-        var listeners = agent.serializeEvents(events);
+      agent.lazyWorker.push({
+        context: agent,
 
-        // save data only if there is
-        var data = {
-            eventId: agent.getEventId(),
-            actionId: agent.getActionId(),
-            startTime: start,
-            endTime: end,
-            eventName: eventName,
-            args: _.map(args, agent.inspectValue, agent),
-            depth: agent.depth,
-            context: agent.inspectValue(context),
-            listeners: listeners
-        };
-        var dataKind = (data === undefined) ? undefined : "event arguments";
+        args: [agent, args, start, end, agent.depth, this, eventName],
+        callback: serializeTrigger
+      });
 
-        addAppComponentAction(this, new AppComponentAction(
-            "trigger", eventName, data, dataKind
-        ));
+      agent.depth--;
 
-        agent.depth--;
-
-        return result;
+      return result;
     };
   });
 }, this);

--- a/extension/js/agent/patches/patchBackboneModel.js
+++ b/extension/js/agent/patches/patchBackboneModel.js
@@ -1,12 +1,18 @@
 
 this.patchBackboneModel = (function(agent) {
 
-  var patchModelEventsChanges = function(model, prop, action, difference, oldValue) {
-    agent.sendAppComponentReport("model:events:change", {
-      cid: model.cid,
-      data: agent.serializeModel(model)
-    })
-  }
+  var patchModelEventsChanges = _.debounce(function(model, prop, action, difference, oldValue) {
+    agent.lazyWorker.push({
+        context: agent,
+        args: [model],
+        callback: function(model) {
+          agent.sendAppComponentReport("model:events:change", {
+            cid: model.cid,
+            data: agent.serializeModel(model)
+          })
+        }
+    });
+  }, 200);
 
   var patchModelDestroy = function(originalFunction) {
     return function() {
@@ -21,22 +27,35 @@ this.patchBackboneModel = (function(agent) {
     }
   }
 
-  var patchModelAttributesChange = function(model, prop, action, difference, oldvalue) {
-    agent.sendAppComponentReport("model:attributes:change", {
-      cid: model.cid,
-      data: agent.serializeModel(model)
-    })
-  }
+  var patchModelAttributesChange = _.debounce(function(model, prop, action, difference, oldvalue) {
+    var data = agent.lazyWorker.push({
+        context: agent,
+        args: [model],
+        callback: function(model) {
+          agent.sendAppComponentReport("model:attributes:change", {
+            cid: model.cid,
+            data: agent.serializeModel(model)
+          })
+        }
+    });
+  }, 200);
+
+
 
   return function(BackboneModel) {
     debug.log("Backbone.Model detected");
 
     patchBackboneComponent(BackboneModel, function(model) { // on new instance
 
-        // registra il nuovo componente dell'app
-        var data = agent.serializeModel(model);
-        var modelIndex = registerAppComponent("Model", model, data);
-
+        agent.lazyWorker.push({
+          context: agent,
+          args: [model],
+          callback: function(model) {
+            // registra il nuovo componente dell'app
+            var data = agent.serializeModel(model);
+            var modelIndex = registerAppComponent("Model", model, data);
+          }
+        });
 
         // monitora i cambiamenti alle proprietà d'interesse del componente dell'app
         // monitorAppComponentProperty(model, "attributes", 1);

--- a/extension/js/agent/patches/patchBackboneRadio.js
+++ b/extension/js/agent/patches/patchBackboneRadio.js
@@ -41,34 +41,62 @@ this.onNewRadioChannel = function(channel, channelName) {
 };
 
 this.onRadioRequestChange = function(channel, newValue, prop, action, difference, oldvalue) {
-  sendAppComponentReport('Channel:change', {
-    channelName: channel.channelName,
-    data: this.serializeChannelRadio(channel)
+  this.lazyWorker.push({
+    context: this,
+    args: [channel],
+    callback: function() {
+      this.sendAppComponentReport('Channel:change', {
+        channelName: channel.channelName,
+        data: this.serializeChannelRadio(channel)
+      });
+    }
   });
+
   debug.log('channel request change', channel.channelName);
 };
 
 this.onRadioCommandChange = function(channel, newValue, prop, action, difference, oldvalue) {
-  sendAppComponentReport('Channel:change', {
-    channelName: channel.channelName,
-    data: this.serializeChannelRadio(channel)
+  this.lazyWorker.push({
+    context: this,
+    args: [channel],
+    callback: function() {
+      this.sendAppComponentReport('Channel:change', {
+        channelName: channel.channelName,
+        data: this.serializeChannelRadio(channel)
+      });
+    }
   });
+
   debug.log('channel command change', channel.channelName);
 };
 
 this.onRadioEventChange = function(channel, newValue, prop, action, difference, oldvalue) {
-  sendAppComponentReport('Channel:change', {
-    channelName: channel.channelName,
-    data: this.serializeChannelRadio(channel)
+  this.lazyWorker.push({
+    context: this,
+    args: [channel],
+    callback: function() {
+      this.sendAppComponentReport('Channel:change', {
+        channelName: channel.channelName,
+        data: this.serializeChannelRadio(channel)
+      });
+    }
   });
+
   debug.log('channel event change', channel.channelName);
 };
 
 this.reportNewRadioChannel = function(channel, channelName) {
-  sendAppComponentReport('Channel:new', {
-    channelName: channel.channelName,
-    data: this.serializeChannelRadio(channel)
+  this.lazyWorker.push({
+    context: this,
+    args: [channel],
+    callback: function() {
+      this.sendAppComponentReport('Channel:new', {
+        channelName: channel.channelName,
+        data: this.serializeChannelRadio(channel)
+      });
+    }
   });
+
   debug.log('new channel', channel.channelName);
 };
 

--- a/extension/js/agent/patches/patchBackboneView.js
+++ b/extension/js/agent/patches/patchBackboneView.js
@@ -1,9 +1,15 @@
-this.patchViewChanges = function(view, prop, action, difference, oldValue) {
-  this.sendAppComponentReport("view:change", {
-    cid: view.cid,
-    data: this.serializeView(view)
-  })
-}
+this.patchViewChanges = _.debounce(function(view, prop, action, difference, oldValue) {
+  this.lazyWorker.push({
+    context: this,
+    args: [view],
+    callback: function(view) {
+      this.sendAppComponentReport("view:change", {
+        cid: view.cid,
+        data: this.serializeView(view)
+      });
+    }
+  });
+}, 200);
 
 var patchViewRemove = function(originalFunction) {
   return function() {
@@ -23,10 +29,20 @@ this.patchBackboneView = function(BackboneView) {
     debug.log("Backbone.View detected");
 
     patchBackboneComponent(BackboneView, bind(function(view) { // on new instance
-        // registra il nuovo componente dell'app
-        var data = this.serializeView(view);
-        var viewIndex = registerAppComponent("View", view, data);
+        this.lazyWorker.push({
+          context: this,
+          args: [view],
+          callback: function(view) {
+            var data = this.serializeView(view)
+            this.sendAppComponentReport("view:change", {
+              data: data,
+              cid: view.cid
+            });
+          }
+        });
 
+        // registra il nuovo componente dell'app
+        this.registerAppComponent("View", view, this.serializeEmptyView(view));
 
         // Patcha i metodi del componente dell'app
         patchAppComponentTrigger(view, 'view');

--- a/extension/js/agent/patches/patchBackboneWreqr.js
+++ b/extension/js/agent/patches/patchBackboneWreqr.js
@@ -41,33 +41,60 @@ this.onNewWreqrChannel = function(channel, channelName) {
 }
 
 this.onWreqrRequestChange = function(channel, newValue, prop, action, difference, oldvalue) {
-  sendAppComponentReport('Channel:change', {
-    channelName: channel.channelName,
-    data: this.serializeWreqrChannel(channel)
+  this.lazyWorker.push({
+    context: this,
+    args: [channel],
+    callback: function() {
+      this.sendAppComponentReport('Channel:change', {
+        channelName: channel.channelName,
+        data: this.serializeWreqrChannel(channel)
+      });
+    }
   });
+
   debug.log('channel request change', channel.channelName);
 };
 
 this.onWreqrCommandChange = function(channel, newValue, prop, action, difference, oldvalue) {
-  sendAppComponentReport('Channel:change', {
-    channelName: channel.channelName,
-    data: this.serializeWreqrChannel(channel)
+  this.lazyWorker.push({
+    context: this,
+    args: [channel],
+    callback: function() {
+      this.sendAppComponentReport('Channel:change', {
+        channelName: channel.channelName,
+        data: this.serializeWreqrChannel(channel)
+      });
+    }
   });
+
   debug.log('channel command change', channel.channelName);
 };
 
 this.onWreqrEventChange = function(channel, newValue, prop, action, difference, oldvalue) {
-  sendAppComponentReport('Channel:change', {
-    channelName: channel.channelName,
-    data: this.serializeWreqrChannel(channel)
+  this.lazyWorker.push({
+    context: this,
+    args: [channel],
+    callback: function() {
+      this.sendAppComponentReport('Channel:change', {
+        channelName: channel.channelName,
+        data: this.serializeWreqrChannel(channel)
+      });
+    }
   });
+
   debug.log('channel event change', channel.channelName);
 };
 
 this.reportNewWreqrChannel = function(channel, channelName) {
-  sendAppComponentReport('Channel:new', {
-    channelName: channel.channelName,
-    data: this.serializeWreqrChannel(channel)
+  this.lazyWorker.push({
+    context: this,
+    args: [channel],
+    callback: function() {
+      this.sendAppComponentReport('Channel:new', {
+        channelName: channel.channelName,
+        data: this.serializeWreqrChannel(channel)
+      });
+    }
   });
   debug.log('new channel', channel.channelName);
 };

--- a/extension/js/agent/utils/lazyWorker.js
+++ b/extension/js/agent/utils/lazyWorker.js
@@ -1,0 +1,79 @@
+;(function(Agent){
+
+  Agent.LazyWorker = Marionette.Object.extend({
+
+    // time to wait until starting work
+    deferTime: 200,
+
+    // time to work and potentially freeze the screen
+    workTime: 80,
+
+    initialize: function() {
+      this.initTime = new Date();
+      this.queue = [];
+      this.startWork = _.debounce(this.startWork, this.deferTime);
+      // this.logSize();
+    },
+
+    push: function(job) {
+      // console.log('** callee', Agent.stackFrame(8));
+      // console.log('push called', this.queue.length, new Date() - this.initTime);
+
+      this.queue.push(job);
+      this.triggerMethod('push');
+      this.startWork();
+    },
+
+    startWork: function() {
+      if (this.isWorking) {
+        return;
+      }
+
+      this.triggerMethod('work:start');
+      // window.setTimeout(this.stopWork.bind(this), this.workTime);
+      this.isWorking = true;
+      this.startTime = new Date();
+      var job;
+
+      while (this.isWorking) {
+        //console.log('working loop called', this.queue.length, new Date() - this.initTime);
+
+        var job = this.queue.shift();
+        if (!job) {
+          //console.log('queue is empty', new Date() - this.startTime)
+          this.stopWork();
+          this.triggerMethod('queue:empty');
+          return;
+        }
+
+
+        job.callback.apply(job.context, job.args);
+
+        if (new Date() - this.startTime > this.workTime) {
+          //console.log('time has elapsed', new Date() - this.startTime)
+          this.stopWork();
+          this.startWork();
+          return;
+        }
+      }
+    },
+
+    stopWork: function() {
+      if (!this.isWorking) {
+        return;
+      }
+
+      //console.log('stop work called', new Date() - this.startTime);
+      this.triggerMethod('work:stop')
+      this.isWorking = false;
+    },
+
+    logSize: function() {
+      window.setInterval(function() {
+        console.log('!!! queue size', __agent.lazyWorker.queue.length)
+      }, 1000);
+    }
+
+  });
+
+}(this));

--- a/extension/js/agent/utils/stackFrame.js
+++ b/extension/js/agent/utils/stackFrame.js
@@ -1,0 +1,18 @@
+
+;(function(Agent) {
+  Agent.stackFrame = function (i) {
+    try {0()} catch (e) {
+      var stack = e.stack;
+      stack = stack.substr(stack.indexOf('\n')+1);
+    }
+
+    if (!stack) return;
+
+    var lines = stack.split(/\n/);
+    var line = lines[i-1];
+    if (!line) return;
+
+    return line.trim().split(/\(/)[0];
+  }
+
+}(this));

--- a/extension/js/inspector/app/modules/UI/views/Layout.js
+++ b/extension/js/inspector/app/modules/UI/views/Layout.js
@@ -59,8 +59,8 @@ define([
           viewCollection: this.options.viewCollection
         }));
 
-        this.viewTreeModel.collapse();
-        this.viewTreeModel.expandPath('app');
+        // this.viewTreeModel.collapse();
+        // this.viewTreeModel.expandPath('app');
       } else {
         this.viewTreeModel.updateNodes(tree.nodes);
       }
@@ -70,6 +70,7 @@ define([
       var viewModel = this.options.viewCollection.findView(data.cid)
 
       if (!viewModel) {
+        console.log('couldnt find the view', data.cid);
         return;
       }
 

--- a/extension/js/lib/watch.js
+++ b/extension/js/lib/watch.js
@@ -459,7 +459,18 @@
 
     };
 
-    setInterval(loop, 50);
+    setInterval(function() {
+        if(!__agent) return
+
+        __agent.lazyWorker.push({
+          context: this,
+          args: [],
+          callback: loop
+        })
+
+    }, 500);
+
+    // setInterval(loop, 50);
 
     WatchJS.watch = watch;
     WatchJS.unwatch = unwatch;

--- a/extension/js/test/unit/AgentSpecRunner.html
+++ b/extension/js/test/unit/AgentSpecRunner.html
@@ -93,9 +93,11 @@
     <script src="agent/marionette/serialize/serializeView.spec.js"></script>
     <script src="agent/marionette/serialize/serializeModel.spec.js"></script>
     <script src="agent/utils/inspectValue.spec.js"></script>
+    <script src="agent/utils/lazyWorker.spec.js"></script>
     <script src="agent/utils/serializeObject.spec.js"></script>
     <script src="agent/patches/patchDefineCallback.spec.js"></script>
     <script src="agent/creating-a-model.spec.js"></script>
+
 
   </head>
   <body>

--- a/extension/js/test/unit/agent/utils/lazyWorker.spec.js
+++ b/extension/js/test/unit/agent/utils/lazyWorker.spec.js
@@ -1,0 +1,146 @@
+function fib(n) {
+  var i;
+  var fib = [];
+
+  fib[0] = 0;
+  fib[1] = 1;
+  for(i=2; i<=n; i++) {
+      fib[i] = fib[i-2] + fib[i-1];
+  }
+
+  return fib[n];
+}
+
+
+describe('lazyWorker', function() {
+  beforeEach(function() {
+    window.startTestTime = new Date();
+    this.worker = new window.LazyWorker();
+    this.startTime = new Date();
+  });
+
+  describe('jobs added synchronously', function() {
+    beforeEach(function(done) {
+      this.job1 = sinon.stub();
+      this.worker.push({
+        context: {},
+        callback: this.job1,
+        args: []
+      });
+
+      this.job2 = sinon.stub();
+      this.worker.push({
+        context: {},
+        callback: this.job2,
+        args: []
+      });
+
+      this.worker.on('queue:empty', done);
+    })
+
+    it('it did some work', function() {
+      expect(this.job1).to.be.calledOnce
+      expect(this.job2).to.be.calledOnce
+    });
+
+    it('it started after some time', function() {
+      this.stopTime = new Date();
+      expect(this.stopTime - this.startTime).to.be.above(100);
+    });
+  })
+
+
+  describe('jobs added asynchronously', function() {
+    beforeEach(function(done) {
+      window.setTimeout(function() {
+        this.job1 = sinon.stub();
+        this.worker.push({
+          context: {},
+          callback: this.job1,
+          args: []
+        });
+      }.bind(this), 10)
+
+      window.setTimeout(function() {
+        this.job2 = sinon.stub();
+        this.worker.push({
+          context: {},
+          callback: this.job2,
+          args: []
+        });
+      }.bind(this), 80)
+
+      this.worker.on('queue:empty', done);
+
+      this.stopWorkSpy = sinon.stub();
+      this.worker.on('work:stop', this.stopWorkSpy);
+
+      this.worker.on('push', function() {
+        this.lastPushTime = new Date();
+      }, this);
+    })
+
+    it('it did some work', function() {
+      expect(this.job1).to.be.calledOnce
+      expect(this.job2).to.be.calledOnce
+    });
+
+    it('calls stop work', function() {
+      expect(this.stopWorkSpy.callCount).to.be.eql(1);
+    })
+
+    it('waits more than deferTime to start', function() {
+      this.stopTime = new Date();
+      expect(this.stopTime - this.lastPushTime).to.be.above(this.worker.deferTime);
+    });
+
+    it('it started after some time', function() {
+      this.stopTime = new Date();
+      var totalTime = this.stopTime - this.startTime;
+      console.log('slow jobs worker took', totalTime);
+      expect(totalTime).to.be.above(150);
+    });
+  })
+
+  describe('slow jobs added', function() {
+    beforeEach(function(done) {
+
+      this.job1 = sinon.stub();
+      this.worker.push({
+        context: this,
+        callback: function() {fib(2000000); this.job1();},
+        args: []
+      });
+
+      this.job2 = sinon.stub();
+      this.worker.push({
+        context: this,
+        callback: function() {fib(2000000); this.job2();},
+        args: []
+      });
+
+      this.worker.on('queue:empty', done);
+      this.stopWorkSpy = sinon.stub();
+      this.worker.on('work:stop', this.stopWorkSpy);
+    })
+
+    it('it did some work', function() {
+      expect(this.job1).to.be.calledOnce
+      expect(this.job2).to.be.calledOnce
+    });
+
+    it('calls stop work', function() {
+      // called first time when starting the second job because the first took so long
+      // called second time when looking for a third job and seeing it's empty
+      // called third time...
+      expect(this.stopWorkSpy.callCount).to.be.eql(3);
+    })
+
+    it('it started after some time', function() {
+      this.stopTime = new Date();
+      var totalTime = this.stopTime - this.startTime;
+      console.log('slow jobs worker took', totalTime);
+      expect(totalTime).to.be.above(250);
+    });
+  })
+});


### PR DESCRIPTION
#### Overview:

One of the problems we've seen while auditing the inspector's perf, is that the injected script (agent) is a CPU hog during app start and app navigation. The reason for this, we believe, is that serializing hundreds of views and models can take about as much time as it takes to create and show the page layout. 

Our solution for this is to defer the work of serializing the views and models until after the layout has been created and shown. Enters the LazyWorker. The LazyWorker is responsible for queueing up work that it will do when things settle down. Another feature of the LazyWorker is that it will not work for more than it's alotted time. That means that the LazyWorker should not use up valuable cpu cycles when we're showing a layout nor should it create significant jank because it does not run for too long either. 

Thanks @joshbedo for pairing on this
### Takeaway

The inspector went from taking 10 second for a large layout render to <1 seconds. Translated into experience, it went from shitty to approximately normal app perf. this is awesome sauce...
### review plz

@paulfalgout, @cmaher, @ianmstew, @samccone, @thejameskyle, @jmeas, @megawac  - mind lending your time to this guy? This is an important pattern that we're setting up so I'd like to get as much of a critical discussion as possible now...
