### PR TITLE
Changing project version number of package.json to follow SemVer guidelines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marionette.inspector",
 
-  "version": "0.3",
+  "version": "0.3.0",
 
   "description": "A proper inspector for Marionette",
 


### PR DESCRIPTION
I recently kept seeing this error when I was trying to do `npm install` inside the project directory. I found out that the `package.json` project version wasn't parseable by [node-semver](https://github.com/npm/node-semver). I just changed it to `0.3.0` so it's valid.

```
Joshs-MacBook-Pro:marionette.inspector jbedo$ npm install
npm ERR! install Couldn't read dependencies
npm ERR! Error: Invalid version: "0.2"
npm ERR!     at Object.module.exports.fixVersionField (/usr/local/lib/node_modules/npm/node_modules/read-package-json/node_modules/normalize-package-data/lib/fixer.js:185:13)
npm ERR!     at /usr/local/lib/node_modules/npm/node_modules/read-package-json/node_modules/normalize-package-data/lib/normalize.js:29:38
npm ERR!     at Array.forEach (native)
npm ERR!     at normalize (/usr/local/lib/node_modules/npm/node_modules/read-package-json/node_modules/normalize-package-data/lib/normalize.js:28:15)
npm ERR!     at final (/usr/local/lib/node_modules/npm/node_modules/read-package-json/read-json.js:328:33)
npm ERR!     at then (/usr/local/lib/node_modules/npm/node_modules/read-package-json/read-json.js:126:33)
npm ERR!     at /usr/local/lib/node_modules/npm/node_modules/read-package-json/read-json.js:317:40
npm ERR!     at fs.js:266:14
npm ERR!     at /usr/local/lib/node_modules/npm/node_modules/graceful-fs/graceful-fs.js:105:5
npm ERR!     at Object.oncomplete (fs.js:107:15)
npm ERR! If you need help, you may report this *entire* log,
npm ERR! including the npm and node versions, at:
npm ERR!     <http://github.com/npm/npm/issues>

npm ERR! System Darwin 13.4.0
npm ERR! command "node" "/usr/local/bin/npm" "install"
npm ERR! cwd /Users/jbedo/Desktop/marionette.inspector
npm ERR! node -v v0.10.26
npm ERR! npm -v 1.4.3
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/jbedo/Desktop/marionette.inspector/npm-debug.log
npm ERR! not ok code 0
```
