### PR TITLE
patch window fix to prevent patch marionette before patch backbone

### DIFF
--- a/extension/js/agent/patches/patchWindow.js
+++ b/extension/js/agent/patches/patchWindow.js
@@ -31,9 +31,12 @@ var patchWindow = function(patchBackbone, patchMarionette) {
     debug.log('marionette loaded');
 
     var Marionette = window.Marionette || loadedBackbone.Marionette;
-    patchMarionette(loadedBackbone, Marionette);
+    if (loadedBackbone) {
+      patchMarionette(loadedBackbone, Marionette);
+    }
   }
 
   waitForBackboneLoad(onBackboneLoaded);
+  waitForMarionetteLoad(window, onMarionetteLoaded);
 };
 


### PR DESCRIPTION
@jasonLaster looks like just removing the one line does the trick. Allow waitForMarionetteLoad to only be called in onBackboneLoaded callback.
