### PR TITLE
Fix issue where properties were not being removed properly

### DIFF
--- a/extension/js/agent/utils/serializeObject.js
+++ b/extension/js/agent/utils/serializeObject.js
@@ -122,5 +122,8 @@ this.serializeObjectProperties = function(object) {
     properties.push(this.serializeClass(object, info, true));
   }, this)
 
-  return _.extend.apply(_, properties);
+  // reverse the list of properties so that the
+  // topmost ancestor properties come first and the instance properties
+  // come last.
+  return _.extend.apply(_, [{}].concat(properties.reverse()));
 };

--- a/extension/js/test/unit/agent/utils/serializeObject.spec.js
+++ b/extension/js/test/unit/agent/utils/serializeObject.spec.js
@@ -1,29 +1,45 @@
 describe('serializeObject', function() {
+  beforeEach(function() {
+    this.Class = window.patchedMarionette.ItemView.extend({
+      _className: 'Class',
+      fooFunc: function() {},
+      tagName: 'li'
+    })
+
+    this.view = new this.Class();
+  });
+
+  describe('serializeObjectProperties', function() {
+    beforeEach(function() {
+      this.data = window.serializeObjectProperties(this.view);
+    });
+
+    it('properly serializes overriden properties', function() {
+      expect(this.data.tagName.value).to.equal('li');
+    });
+  });
+
   describe('ancestorInfo', function() {
     beforeEach(function() {
-      this.Class = window.patchedMarionette.ItemView.extend({
-        _className: 'Class',
-        fooFunc: function() {}
-      })
-
-      this.view = new this.Class();
       this.data = window.ancestorInfo(this.view);
     })
 
-    it('serializes properties', function() {
+    it('serializes property keys', function() {
       var classData = this.data[0];
       expect(classData.name).to.equal('Class');
-      expect(classData.keys).to.deep.equal([
+      expect(classData.keys).to.contain(
         "render", "options", "events", "cid",
         "$el", "el", "trigger", "ui", "remove",
         "_listeningTo", "_listenId", "_events"
-      ]);
+      );
     });
 
     it('serializes Class', function() {
       var classData = this.data[1];
       expect(classData.name).to.equal('Class');
-      expect(classData.keys).to.deep.equal(["constructor", "_className", "fooFunc"]);
+      expect(classData.keys).to.contain(
+        "constructor", "_className", "fooFunc", "li"
+      );
     });
 
     it('serializes ItemView', function() {


### PR DESCRIPTION
fixes #116.
@jdaudier and @randcode-generator - We got it.

There was a pretty subtle bug that showed up in the way we were serializing objects and there ancestors, where the ancestor properties (Backbone.View.prototype.tagName) took precedence over class properties (MyListItem.prototype.tagName). This fixes that by reversing the list of properties and adding an empty `{}` to the front so that nothing is overriden.
