### PR TITLE
[agent] Update agent console messages

### DIFF
--- a/extension/js/agent/agent.js
+++ b/extension/js/agent/agent.js
@@ -23,5 +23,17 @@ this.start = function(Backbone, Marionette) {
 };
 
 
-console.log('marionette inspector', this);
+console.log('Marionette Inspector: window.__agent = ', this);
 sendAppComponentReport('start');
+
+
+window.setTimeout(function() {
+
+  if(window.__agent && window.__agent.patchedBackbone) {
+    return;
+  }
+
+  console.warn("Marionette Inspector: Hmmm... couldn't find yo Backbone");
+  console.log("Please peruse https://github.com/marionettejs/marionette.inspector#caveats");
+
+}, 2000);


### PR DESCRIPTION
This new warning will direct people to the install section of the readme if the inspector fails to automatically detect Backbone.
