### PR TITLE
Simply unwrapper

### DIFF
--- a/extension/js/agent/utils/unwrapListenToOnceWrapper.js
+++ b/extension/js/agent/utils/unwrapListenToOnceWrapper.js
@@ -1,34 +1,7 @@
 (function(Agent) {
 
-  var underscoreListenOnceFuncString = function () {
-        if (ran) return memo;
-        ran = true;
-        memo = func.apply(this, arguments);
-        func = null;
-        return memo;
-      }.toString();
-
-  var lodashListenOnceFuncString = function() {
-          if (ran) {
-            return result;
-          }
-          ran = true;
-          result = func.apply(this, arguments);
-
-          // clear the `func` variable so the function may be garbage collected
-          func = null;
-          return result;
-        }.toString();
-
   Agent.unwrapListenToOnceWrapper = function(func) {
-    var funcString = func.toString();
-    if (underscoreListenOnceFuncString == funcString
-      || lodashListenOnceFuncString == funcString) {
-
-      return func._callback;
-    }
-
-    return func;
+    return func._callback || func;
   }
 
 })(this);


### PR DESCRIPTION
Resolves: https://github.com/marionettejs/marionette.inspector/issues/164

This works with clients with minified or versions of underscore>1.6.

And it works with recent versions of backbone.  I also cannot find any evidence that this will change in 1.2, but if it does, this function will still be broken with or without this update.
