### PR TITLE
[inspector] Add activity features

### DIFF
--- a/extension/css/inspector/partials/_activity-panel.scss
+++ b/extension/css/inspector/partials/_activity-panel.scss
@@ -1,9 +1,40 @@
 
-.activity-row td.depth-0 {padding-left:0px;}
-.activity-row td.depth-1 {padding-left:10px;}
-.activity-row td.depth-2 {padding-left:20px;}
-.activity-row td.depth-3 {padding-left:30px;}
-.activity-row td.depth-4 {padding-left:40px;}
-.activity-row td.depth-5 {padding-left:50px;}
-.activity-row td.depth-6 {padding-left:60px;}
-.activity-row td.depth-7 {padding-left:70px;}
+.app-tool.activity {
+  .activity-row td.depth-0 {padding-left:0px;}
+  .activity-row td.depth-1 {padding-left:10px;}
+  .activity-row td.depth-2 {padding-left:20px;}
+  .activity-row td.depth-3 {padding-left:30px;}
+  .activity-row td.depth-4 {padding-left:40px;}
+  .activity-row td.depth-5 {padding-left:50px;}
+  .activity-row td.depth-6 {padding-left:60px;}
+  .activity-row td.depth-7 {padding-left:70px;}
+
+
+  li.tree-group-item {
+
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    .event {
+    }
+
+    .context {
+      color: #bbb;
+      &.is-detatched {
+        color: #F57F7F;
+      }
+    }
+
+    &.node-active {
+      a {
+        color: white;
+
+        &.context {
+          color: white;
+        }
+      }
+    }
+  }
+}
+

--- a/extension/css/inspector/partials/_tree-view.scss
+++ b/extension/css/inspector/partials/_tree-view.scss
@@ -40,7 +40,7 @@ li.tree-group-item {
 
   &:hover {
     color: #428BCA;
-    cursor: pointer;
+    // cursor: pointer;
     background: #f2f2f2;
   }
 

--- a/extension/js/inspector/app/behaviors/ClickableProperties.js
+++ b/extension/js/inspector/app/behaviors/ClickableProperties.js
@@ -41,8 +41,8 @@ define([
       var $target = $(e.currentTarget);
       var $property = $target.closest('li');
 
-      var type = $property.data('property-context-type');
-      var cid = $property.data('property-context-cid');
+      var type = $property.data('property-context-type') || '';
+      var cid = $property.data('property-context-cid') || '';
 
       if(isTypeNavigable(type)) {
         this.navigateTo({

--- a/extension/js/inspector/app/modules/Activity.js
+++ b/extension/js/inspector/app/modules/Activity.js
@@ -16,7 +16,8 @@ define([
     lastActivityModel: undefined,
 
     clientEvents: {
-      "agent:View:trigger": 'onViewTrigger'
+      "agent:View:trigger": 'onTrigger',
+      "agent:Model:trigger": 'onTrigger'
     },
 
     activityRequests: {
@@ -41,7 +42,7 @@ define([
     },
 
     // See patchAppComponentTrigger.js for definition of event.data
-    onViewTrigger: function(event) {
+    onTrigger: function(event) {
       logger.log('activity', 'new event', event.name);
 
       this.activityCollection.add(event.data);

--- a/extension/js/inspector/app/modules/Activity/views/Layout.js
+++ b/extension/js/inspector/app/modules/Activity/views/Layout.js
@@ -28,7 +28,7 @@ define([
       'add remove reset': 'onChangeActivityCollection'
     },
 
-    className: 'app-tool',
+    className: 'app-tool activity',
 
     activityCollection: undefined,
     activityRoot: undefined,

--- a/extension/js/inspector/app/modules/Data/views/Layout.js
+++ b/extension/js/inspector/app/modules/Data/views/Layout.js
@@ -73,6 +73,9 @@ define([
     },
 
     showInfo: function(data) {
+      if (!data.instance) {
+        return;
+      }
 
       data.instance.trigger('highlight');
       if (data.type == 'model') {

--- a/extension/js/inspector/app/modules/UI.js
+++ b/extension/js/inspector/app/modules/UI.js
@@ -44,6 +44,11 @@ define([
       'agent:ui:regionTree': 'onRegionTree'
     },
 
+    uiRequests: {
+      'view': 'requestView',
+      'view:node': 'requestViewNode'
+    },
+
     appEvents: {
       'agent:start': 'onAgentStart'
     },
@@ -73,11 +78,25 @@ define([
     setupEvents: function() {
       Radio.connectCommands('ui', this.uiCommands, this);
       Radio.connectEvents('app', this.appEvents, this);
+      Radio.connectRequests('ui', this.uiRequests, this);
+
 
       Marionette.bindEntityEvents(this, this.client, this.clientEvents);
 
       var regionTreeEvents = new ComponentReportToRegionTreeMap();
       Marionette.bindEntityEvents(this, regionTreeEvents, this.regionTreeEvents);
+    },
+
+    requestView: function(cid) {
+      return this.viewCollection.findView(cid);
+    },
+
+    requestViewNode: function(cid) {
+      return this.getViewNode(cid);
+    },
+
+    getViewNode: function(cid) {
+      return this.uiData.findViewTreeNodeByCid(cid);
     },
 
     onAgentStart: function() {
@@ -198,7 +217,7 @@ define([
     },
 
     showViewInfo: function(cid) {
-      var node = this.uiData.findViewTreeNodeByCid(cid);
+      var node = this.getViewNode(cid);
       if (!node) {
         return;
       }

--- a/extension/js/inspector/app/modules/UI/models/ViewModel.js
+++ b/extension/js/inspector/app/modules/UI/models/ViewModel.js
@@ -12,6 +12,24 @@ define([
        });
     },
 
+    isDetatched: function() {
+      return !this.viewNode();
+    },
+
+    getName: function() {
+      var viewNode = this.viewNode();
+
+      if (viewNode) {
+        return viewNode.name;
+      } else {
+        return "detatched";
+      }
+    },
+
+    viewNode: function() {
+      return Radio.request('ui', 'view:node',  this.get('cid'));
+    },
+
     viewModel: function() {
       if (!this.get('model')) {
         return

--- a/extension/templates/devTools/activity/tree.html
+++ b/extension/templates/devTools/activity/tree.html
@@ -2,14 +2,23 @@
 {{!These are both special cases of the event tree view not seen in the UI tree view.}}
 {{#unless isRoot}}
 {{#if name}}
-  <li class="tree-group-item {{ level }}">
+  <li data-property-context-type="{{context.type}}"
+      data-property-context-cid="{{context.cid}}"
+      class="tree-group-item {{ level }}">
     {{#if hasNodes}}
         <span data-action="toggle" class="toggle-caret glyphicon {{ collapseClass }}"></span>
     {{else}}
       <span style="width:19px; display: inline-block;"></span>
     {{/if}}
 
-    {{ name }}
+    <a data-action="show:event" href="#" class="event"> {{ name }}</a>
+
+    <a
+      data-action="show:context"
+      data-property-value-context href="#"
+      class="context {{#isDetatched}}is-detatched{{/isDetatched}}">
+      {{contextName}}
+    </a>
   </li>
 {{/if}}
 {{/unless}}


### PR DESCRIPTION
I think you guys are going to like this one. I sat down this afternoon and added the context field to the activity tree: (photo)

![](http://f.cl.ly/items/1N2A1H3x133O2D123V1a/Image%202015-01-02%20at%207.48.37%20PM.png)

Now, one thing you can't see in the diff is that I taped this work as I went through it... So, the screencast will be made available sometime tonight when it finishes exporting / uploading to youtube. It's a little bit long, ya'll know that I tend to get excited so you'll hear me say I just want to do one small thing and ofcourse feature creep creeps in... Anyways, I'm really happy with the basics of this feature - you can see all of the sub tasks below but a lot was added to make the activity tree super interesting. 

### Features:
+ Add context to activity tree
+ Clean up styles so that context and event are links
+ Wire up context so that it takes you to the view
+ Add Model events to the activity pane
+ add View Model isDetatche helper
+ add View Model getName helper

