### PR TITLE
Support for Marionette 2.0.0 apps (pre Behaviours)

### DIFF
--- a/extension/js/agent/patches/patchMarionette.js
+++ b/extension/js/agent/patches/patchMarionette.js
@@ -37,19 +37,22 @@ this.patchMarionette = (function(agent) {
     }
 
     this.patchMarionetteApplication(Marionette.Application);
-    this.patchMarionetteBehavior(Marionette.Behavior);
+    if(Marionette.Behavior) {
+      this.patchMarionetteBehavior(Marionette.Behavior);  
+    } 
     this.patchMarionetteModule(Marionette.Module);
     this.patchMarionetteController(Marionette.Controller);
 
-    _.each(
-      [
-        Marionette.Application.prototype, Marionette.Module.prototype,
-        Marionette.Behavior.prototype, Marionette.Region.prototype,
-        Marionette.Controller.prototype
-      ],
+    var marionetteClasses = [
+      Marionette.Application.prototype, Marionette.Module.prototype,
+      Marionette.Region.prototype, Marionette.Controller.prototype
+    ];
 
-      this.patchBackboneTrigger, this
-    );
+    if (Marionette.Behavior) {
+      marionetteClasses.push(Marionette.Behavior.prototype);
+    }
+
+    _.each(marionetteClasses, this.patchBackboneTrigger, this);
   }
 
 }(this));

--- a/extension/js/agent/utils/knownTypes.js
+++ b/extension/js/agent/utils/knownTypes.js
@@ -184,28 +184,16 @@
     }
 
     //Marionette 2.0.0 does not have Radio in Wreqr
-    if (Agent.patchedBackbone.Wreqr) {
-      if(Agent.patchedBackbone.Wreqr.Channel) {
-        _.extend(knownTypes, {
-          'Backbone.Wreqr.Channel': {
-            type: Agent.patchedBackbone.Wreqr.Channel,
-            name: 'wreqr-channel',
-            className: 'Wreqr.Channel',
-            cid: function(obj) { return ''},
-            toString: toString
-          }
-        });
-      } else {
-        _.extend(knownTypes, {
-          'Backbone.Wreqr': {
-            type: Agent.patchedBackbone.Wreqr.__proto__.constructor,
-            name: 'backbone-wreqr',
-            className: 'Backbone.Wreqr',
-            cid: function(obj) { return ''},
-            toString: toString
-          }
-        });
-      }
+    if (Agent.patchedBackbone.Wreqr && Agent.patchedBackbone.Wreqr.Channel) {
+      _.extend(knownTypes, {
+        'Backbone.Wreqr.Channel': {
+          type: Agent.patchedBackbone.Wreqr.Channel,
+          name: 'wreqr-channel',
+          className: 'Wreqr.Channel',
+          cid: function(obj) { return ''},
+          toString: toString
+        }
+      });
     }
 
 

--- a/extension/js/agent/utils/knownTypes.js
+++ b/extension/js/agent/utils/knownTypes.js
@@ -183,17 +183,29 @@
       });
     }
 
-
+    //Marionette 2.0.0 does not have Radio in Wreqr
     if (Agent.patchedBackbone.Wreqr) {
-      _.extend(knownTypes, {
-        'Backbone.Wreqr.Channel': {
-          type: Agent.patchedBackbone.Wreqr.Channel,
-          name: 'wreqr-channel',
-          className: 'Wreqr.Channel',
-          cid: function(obj) { return ''},
-          toString: toString
-        }
-      });
+      if(Agent.patchedBackbone.Wreqr.Channel) {
+        _.extend(knownTypes, {
+          'Backbone.Wreqr.Channel': {
+            type: Agent.patchedBackbone.Wreqr.Channel,
+            name: 'wreqr-channel',
+            className: 'Wreqr.Channel',
+            cid: function(obj) { return ''},
+            toString: toString
+          }
+        });
+      } else {
+        _.extend(knownTypes, {
+          'Backbone.Wreqr': {
+            type: Agent.patchedBackbone.Wreqr.__proto__.constructor,
+            name: 'backbone-wreqr',
+            className: 'Backbone.Wreqr',
+            cid: function(obj) { return ''},
+            toString: toString
+          }
+        });
+      }
     }
 
 


### PR DESCRIPTION
Fix for marionettejs/marionette.inspector#241. Simply checks if Behaviours are present, and checks if Radio / Channels are bundled in Wreqr or not.