### PR TITLE
patchBackboneExtend to add classId to Model, Collection and View

### DIFF
--- a/extension/js/agent/build/core.js
+++ b/extension/js/agent/build/core.js
@@ -113,6 +113,7 @@ var Agent = this;
 // @include ../patches/patchDefineCallback.js
 // @include ../patches/patchDefine.js
 // @include ../patches/patchBackbone.js
+// @include ../patches/patchBackboneExtend.js
 // @include ../patches/patchBackboneComponent.js
 // @include ../patches/patchAppComponentTrigger.js
 // @include ../patches/patchBackboneView.js

--- a/extension/js/agent/patches/patchBackbone.js
+++ b/extension/js/agent/patches/patchBackbone.js
@@ -11,7 +11,7 @@
 
     debug.log('Backbone detected: ', Backbone);
 
-    Agent.patchBackboneView(Backbone.View)
+    Agent.patchBackboneView(Backbone.View);
     Agent.patchBackboneModel(Backbone.Model);
     Agent.patchBackboneCollection(Backbone.Collection);
     Agent.patchBackboneRouter(Backbone.Router);
@@ -19,6 +19,14 @@
     _patchBackboneRadio(Backbone, Agent.patchBackboneRadio);
 
 
+    _.each(
+      [
+        Backbone.Model, Backbone.Collection,
+        Backbone.View
+      ],
+      Agent.patchBackboneExtend
+    );
+    
     _.each(
       [
         Backbone.Events, Backbone.Model.prototype,

--- a/extension/js/agent/patches/patchBackboneExtend.js
+++ b/extension/js/agent/patches/patchBackboneExtend.js
@@ -1,0 +1,16 @@
+;(function(Agent) {
+  
+  Agent.patchBackboneExtend = function(BackboneClass) {
+  
+    Agent.setHiddenProperty(BackboneClass.prototype, 'classId', _.uniqueId('class'));
+    
+    Agent.patchFunction(BackboneClass, 'extend', function(originalExtend) {    
+      return function() {
+        var NewClass = originalExtend.apply(this, arguments);
+        Agent.setHiddenProperty(NewClass.prototype, 'classId', _.uniqueId('class'));
+        return NewClass;
+      };
+    });
+  };
+
+}(Agent));

--- a/extension/js/agent/serializes/serializeChannelWreqr.js
+++ b/extension/js/agent/serializes/serializeChannelWreqr.js
@@ -55,4 +55,4 @@
     return channel.vent._events
   };
 
-})(this);
+})(Agent);

--- a/extension/js/agent/serializes/serializeCollection.js
+++ b/extension/js/agent/serializes/serializeCollection.js
@@ -8,9 +8,10 @@
     }
 
     data.properties = Agent.serializeObjectProperties(collection);
-    data.cid = collection.__marionette_inspector__cid;
-
+    data.cid =  Agent.getHiddenProperty(collection, 'cid');
+    data.classId = Agent.getHiddenProperty(collection, 'classId');
+    
     return data;
   };
 
-})(this);
+})(Agent);

--- a/extension/js/agent/serializes/serializeEvents.js
+++ b/extension/js/agent/serializes/serializeEvents.js
@@ -18,4 +18,4 @@
     }).flatten().value();
   };
 
-})(this);
+})(Agent);

--- a/extension/js/agent/serializes/serializeModel.js
+++ b/extension/js/agent/serializes/serializeModel.js
@@ -14,8 +14,9 @@
     data._previousAttributes = Agent.inspectObject(model._previousAttributes);
     data.changed = Agent.inspectObject(model.changed);
     data.cid = model.cid;
-
+    data.classId = Agent.getHiddenProperty(model, 'classId');
+    
     return data;
   };
 
-})(this);
+})(Agent);

--- a/extension/js/agent/serializes/serializeView.js
+++ b/extension/js/agent/serializes/serializeView.js
@@ -26,6 +26,7 @@
     data._className = Agent.serializeClassName(view);
     data.parentClass = Agent.isKnownType(view) ? Agent.knownType(view).name : '';
     data.inspect = Agent.inspectValue(view);
+    data.classId = Agent.getHiddenProperty(view, 'classId');
 
     if (view.model) {
       data.model = {

--- a/extension/js/test/unit/AgentSpecRunner.html
+++ b/extension/js/test/unit/AgentSpecRunner.html
@@ -33,10 +33,11 @@
     <script src="agent/marionette/serialize/serializeView.spec.js"></script>
     <script src="agent/marionette/serialize/serializeModel.spec.js"></script>
     <script src="agent/utils/inspectValue.spec.js"></script>
-    <script src="agent/utils/lazyWorker.spec.js"></script>
     <script src="agent/utils/serializeObject.spec.js"></script>
+    <script src="agent/patches/patchBackboneExtend.spec.js"></script>
     <script src="agent/patches/patchDefineCallback.spec.js"></script>
     <script src="agent/patches/patchMarionetteApplication.spec.js"></script>
+    <script src="agent/utils/lazyWorker.spec.js"></script>
     <script src="agent/creating-a-model.spec.js"></script>
 
 

--- a/extension/js/test/unit/agent/patches/patchBackboneExtend.spec.js
+++ b/extension/js/test/unit/agent/patches/patchBackboneExtend.spec.js
@@ -1,0 +1,49 @@
+describe('patchBackboneExtend', function () {
+  before(function () {
+      this.classIdKey = '__marionette_inspector__classId';
+  });
+  describe('when calling patched Backbone.Model.extend', function () {
+    beforeEach(function () {
+      this.BaseModel = window.patchedBackbone.Model;
+      this.Model = window.patchedBackbone.Model.extend();
+    });
+
+    it('should have a classId defined on the prototype', function () {
+      expect(this.Model.prototype[this.classIdKey]).to.not.be.null;
+    });
+
+    it('should have a different classId to Backbone.Model', function () {
+      expect(this.Model.prototype[this.classIdKey]).to.not.equal(this.BaseModel.prototype[this.classIdKey]);
+    });
+  });
+  
+  describe('when calling patched Backbone.Collection.extend', function () {
+    beforeEach(function () {
+      this.BaseCollection = window.patchedBackbone.Collection;
+      this.Collection = window.patchedBackbone.Collection.extend();
+    });
+
+    it('should have a classId defined on the prototype', function () {
+      expect(this.Collection.prototype[this.classIdKey]).to.not.be.null;
+    });
+
+    it('should have a different classId to Backbone.Collection', function () {
+      expect(this.Collection.prototype[this.classIdKey]).to.not.equal(this.BaseCollection.prototype[this.classIdKey]);
+    });
+  });
+  
+  describe('when calling patched Backbone.View.extend', function () {
+    beforeEach(function () {
+      this.BaseView = window.patchedBackbone.View;
+      this.View = window.patchedBackbone.View.extend();
+    });
+
+    it('should have a classId defined on the prototype', function () {
+      expect(this.View.prototype[this.classIdKey]).to.not.be.null;
+    });
+
+    it('should have a different classId to Backbone.View', function () {
+      expect(this.View.prototype[this.classIdKey]).to.not.equal(this.BaseView.prototype[this.classIdKey]);
+    });
+  });
+});

--- a/extension/templates/devTools/data/collection-row.html
+++ b/extension/templates/devTools/data/collection-row.html
@@ -1,4 +1,4 @@
-<td class="u-text--nowrap">{{cid}}</td>
+<td class="u-text--nowrap">{{cid}} - {{classId}}</td>
 
 <td data-action="info">
   <a href="#">

--- a/extension/templates/devTools/data/row.html
+++ b/extension/templates/devTools/data/row.html
@@ -1,4 +1,4 @@
-<td class="u-text--nowrap">{{cid}}</td>
+<td class="u-text--nowrap">{{cid}} - {{classId}}</td>
 
 <td data-action="info">
   <a href="#">


### PR DESCRIPTION
This is part of https://github.com/marionettejs/marionette.inspector/issues/160

I've added a classId to the extends as well as the base classes:  Model, Collection, View.  (Should we do router as well?)  It's possible the bases don't need it, but then there will be plenty of instantiated objects with no classId.  This way every instantiation is the same.  Thoughts?

Similarly the example diff on the issue was showing:
`this.__super__.prototype.__marionette_inspector_classId__`
`__super__` is rarely if ever available during the serialization so for now I've left that out.

I've added the `classId` to the list name where the `cid` is currently displayed.  Obviously not the end goal, but it's a start at least for proof of concept.  I've listed the todos below.  I'd appreciate a review now.
I could also see just PRing the agent stuff now with tests and making the view portion a separate todo for this upcoming sprint.  Thoughts there?

Todo:
- [x] Add tests
- [ ] ~~Grouping classIds for display~~
- [ ] ~~Nested list views~~