### PR TITLE
Fixes 271 - Clicking a function in the inspector used to jump to source

### DIFF
--- a/extension/js/inspector/util/clientInspect.js
+++ b/extension/js/inspector/util/clientInspect.js
@@ -36,7 +36,8 @@ define([
 
 
       // inspect a function
-      if (this._.isFunction(prop)) {
+      var underscore = _ || this._;
+      if (underscore.isFunction(prop)) {
         if (this.isNativeFunction(prop)) {
           this.printProperty(prop);
         } else {


### PR DESCRIPTION
This was broken because we were using this._ and that reference was undefined.

this._ was another fix for when _ wasn't in the window. not sure why this._ fails...

![](http://g.recordit.co/R6egoURN0Q.gif)

---

##### SIDE NOTE: I just setup workspaces for working with the Mn Inspector code

I don't know how i worked with out it. Once it was setup, i could add console.logs all throughout the clientInspect code and it'd immediately update both the script and the file. 

Want to setup?
1. right click in the sidebar to add workspace
2. select inspector/extension/js folder
3. right click in clientInspect.js and select map to file
4. prosper

![](http://f.cl.ly/items/1e0m0y1c250f0j2b102u/Image%202015-04-01%20at%202.00.23%20PM.png)