### PR TITLE
fix: better handle undefined / invalid getters

### DIFF
--- a/extension/js/agent/utils/inspectValue.js
+++ b/extension/js/agent/utils/inspectValue.js
@@ -55,7 +55,12 @@
         break;
       }
 
-      v = value[key];
+      try {
+        v = value[key];
+      }
+      catch (error) {
+        v = undefined;
+      }
       t = typeOf(v);
 
       if (Agent.isKnownType(v)) { v = Agent.knownTypeString(v); }

--- a/extension/js/agent/utils/objectPath.js
+++ b/extension/js/agent/utils/objectPath.js
@@ -11,7 +11,12 @@
       return obj;
     }
 
-    return Agent.objectPath(obj[part], _.rest(path), defaultValue);
+    try {
+      return Agent.objectPath(obj[part], _.rest(path), defaultValue);
+    }
+    catch (error) {
+      return defaultValue;
+    }
   };
 
 }(Agent));

--- a/extension/js/lib/watch.js
+++ b/extension/js/lib/watch.js
@@ -375,11 +375,13 @@
     };
 
     var unwatchOne = function (obj, prop, watcher) {
-        for (var i=0; i<obj.watchers[prop].length; i++) {
-            var w = obj.watchers[prop][i];
+        if (obj.watchers[prop] !== undefined) {
+            for (var i=0; i<obj.watchers[prop].length; i++) {
+                var w = obj.watchers[prop][i];
 
-            if(w == watcher) {
-                obj.watchers[prop].splice(i, 1);
+                if(w == watcher) {
+                    obj.watchers[prop].splice(i, 1);
+                }
             }
         }
 


### PR DESCRIPTION
ES5 getters that would normally throw a `ReferenceError` due to lack of
initialization now gracefully degrade to `undefined`.