### PR TITLE
[fixes #278] Make send lazy

### DIFF
--- a/extension/js/agent/utils/sendMessage.js
+++ b/extension/js/agent/utils/sendMessage.js
@@ -35,10 +35,14 @@
     send: function() {
       // console.log('!!!! sending batch message')
       debug.log('postMessage sent ' + this.queue.length + ' messages.');
-      window.postMessage(this.queue, '*');
+      Agent.lazyWorker.push({
+        context: Agent,
+        args: [_.clone(this.queue)],
+        callback: Agent.postMessage
+      });
+
       this.queue = [];
     }
-
   });
 
 
@@ -49,5 +53,9 @@
     options = options || {};
     queuePostMessages.push(message, options);
   };
+
+  Agent.postMessage = function(data) {
+    window.postMessage(data, '*');
+  }
 
 }(Agent));


### PR DESCRIPTION
[fixes #278]

---


Executing a deep `show()` cycle with Marionette.Inspector running revealed a long (500ms) "flat line" on the CPU profiler.  Closer inspection shows `agent.send()` to be 100% responsible for this flat line.  See below.



![screen shot 2015-04-13 at 5 44 25 pm](https://cloud.githubusercontent.com/assets/4119765/7126137/d6aaf55c-e204-11e4-8870-89bc834c0248.png)