### PR TITLE
make serialize collection lazy

### DIFF
--- a/extension/js/agent/patches/patchBackboneCollection.js
+++ b/extension/js/agent/patches/patchBackboneCollection.js
@@ -7,11 +7,17 @@
     Agent.patchBackboneComponent(BackboneCollection, function(collection) { // on new instance
       Agent.addCidToComponent(collection);
 
-      // registra il nuovo componente dell'app
-      var data = Agent.serializeCollection(collection);
-      var collectionIndex = Agent.registerAppComponent('Collection', collection, data);
+      Agent.lazyWorker.push({
+        context: Agent,
+        args: [collection],
+        callback: function(collection) {
+          // registra il nuovo componente dell'app
+          var data = Agent.serializeCollection(collection);
+          var collectionIndex = Agent.registerAppComponent('Collection', collection, data);
+          debug.log('found new collection', collection, data);
+        }
+      });
 
-      debug.log('found new collection', collection, data);
 
       // Patcha i metodi del componente dell'app
       Agent.patchAppComponentTrigger(collection);


### PR DESCRIPTION
`serializeCollection` takes up a ton of time relative to everything around it by not delegating to the lazy worker

![screenshot 2015-04-13 18 26 32](https://cloud.githubusercontent.com/assets/254562/7126834/d09c7d38-e20a-11e4-8e76-aa029ae09c4d.jpg)
