### PR TITLE
Refactor loop to remove customization from watch.js

### DIFF
--- a/extension/js/agent/actions/observeChanges.js
+++ b/extension/js/agent/actions/observeChanges.js
@@ -1,0 +1,42 @@
+;(function(Agent) {
+  Agent.observeChanges = function() {
+    if(!Agent) return
+
+    var total = WatchJS.lengthsubjects.length;
+    var increment = 500;
+
+    if (total == 0) {
+        return;
+    }
+
+    if (total < increment) {
+        Agent.lazyWorker.push({
+          context: this,
+          args: [0, total],
+          callback: WatchJS.loop
+        });
+    } else {
+        // Do the first n thousand loops
+        // if there are 15633 tasks do them in chunks 0-999, 1000-1999
+        var n = Math.ceil(total / increment);
+        for (var i = 0; i < n; i++) {
+           Agent.lazyWorker.push({
+             context: this,
+             args: [i*increment, (i+1)*increment-1],
+             callback: WatchJS.loop
+           });
+        }
+
+      // do the remaining tasks now
+      // if there are 15,633 task, we've already done
+      // the first 14999, now we'll 1500 - 1633
+      var remainder = total % increment;
+      Agent.lazyWorker.push({
+        context: this,
+        args: [n*increment, n*increment+remainder],
+        callback: WatchJS.loop
+      });
+
+    }
+  }
+}(Agent));

--- a/extension/js/agent/agent.js
+++ b/extension/js/agent/agent.js
@@ -30,6 +30,7 @@
 
   Agent.startAnalytics();
   Agent.lazyWorker = new Agent.LazyWorker();
+  setInterval(Agent.observeChanges, 500);
 
 }(Agent));
 

--- a/extension/js/agent/build/core.js
+++ b/extension/js/agent/build/core.js
@@ -139,6 +139,7 @@ var Agent = this;
 // @include ../actions/highlightEl.js
 // @include ../actions/search.js
 // @include ../actions/analytics.js
+// @include ../actions/observeChanges.js
 
 /*
  * MARIONETTE

--- a/extension/js/agent/utils/lazyWorker.js
+++ b/extension/js/agent/utils/lazyWorker.js
@@ -73,7 +73,7 @@
 
     logSize: function() {
       window.setInterval(function() {
-        console.log('!!! queue size', __agent.lazyWorker.queue.length)
+        console.log('!!! queue size', Agent.lazyWorker.queue.length)
       }, 1000);
     }
 

--- a/extension/js/lib/watchjs/src/watch.js
+++ b/extension/js/lib/watchjs/src/watch.js
@@ -464,51 +464,11 @@
 
     };
 
-
-    setInterval(function() {
-        if(!__agent) return
-
-        var total = lengthsubjects.length;
-        var increment = 500;
-
-        if (total == 0) {
-            return;
-        }
-
-        if (total < increment) {
-            __agent.lazyWorker.push({
-              context: this,
-              args: [0, total],
-              callback: loop
-            });
-        } else {
-            // Do the first n thousand loops
-            // if there are 15633 tasks do them in chunks 0-999, 1000-1999
-            var n = Math.ceil(total / increment);
-            for (var i = 0; i < n; i++) {
-               __agent.lazyWorker.push({
-                 context: this,
-                 args: [i*increment, (i+1)*increment-1],
-                 callback: loop
-               });
-            }
-
-          // do the remaining tasks now
-          // if there are 15,633 task, we've already done
-          // the first 14999, now we'll 1500 - 1633
-          var remainder = total % increment;
-          __agent.lazyWorker.push({
-            context: this,
-            args: [n*increment, n*increment+remainder],
-            callback: loop
-          });
-
-        }
-    }, 200);
-
     WatchJS.watch = watch;
     WatchJS.unwatch = unwatch;
     WatchJS.callWatchers = callWatchers;
+    WatchJS.loop = loop;
+    WatchJS.lengthsubjects = lengthsubjects;
 
     return WatchJS;
 

--- a/extension/js/test/unit/agent_test_setup.js
+++ b/extension/js/test/unit/agent_test_setup.js
@@ -25,6 +25,7 @@
 
   var originalHash = window.location.hash;
 
+  window.__agent = {};
 
   before(function() {
       this.setFixtures = setFixtures;


### PR DESCRIPTION
This extracts the watch js heartbeat so that runs the watcher loop. In lay man terms, the code that tells watch js to check for changes.

The reason that this code was breaking the tests was that the hearbeat checked to see if __agent was on the page, in the tests it wasn't. I extracted the code for a little bit of dependency sanity.