### PR TITLE
Panels stack at small widths

### DIFF
--- a/extension/css/inspector/main.scss
+++ b/extension/css/inspector/main.scss
@@ -1,3 +1,6 @@
+// mixins
+@import "partials/mixins/media-queries";
+
 // utilities
 @import "partials/utility";
 

--- a/extension/css/inspector/partials/_layout.scss
+++ b/extension/css/inspector/partials/_layout.scss
@@ -1,9 +1,9 @@
-html {
+html, body {
   height: 100%;
 }
 
+
 body {
-  height: 100%;
   overflow: hidden;
 }
 
@@ -26,16 +26,30 @@ body {
 
 // shared between both panels
 .tool-panel {
-    float: left;
     overflow: auto;
 }
 
 // panel on the left, with list of info
 .list-panel {
-    width: 40%;
+    height: 40%;
 }
 
 // panel on the right, with details on info
 .info-panel {
-    width: 60%;
+    height: 60%;
+}
+
+@include mq-medium {
+  .tool-panel {
+    float: left;
+    height: 100%;
+  }
+
+  .list-panel {
+      width: 40%;
+  }
+
+  .info-panel {
+      width: 60%;
+  }
 }

--- a/extension/css/inspector/partials/_panel-list.scss
+++ b/extension/css/inspector/partials/_panel-list.scss
@@ -8,6 +8,14 @@ li.channel-row:hover, .model-row:hover {
 }
 
 // the container that wraps all lists on the left
+// border on the bottom for when panels are stacked
 .list-panel {
-    border-right: 1px solid #e7e7e7;
+    border-bottom: 1px solid #e7e7e7;
+}
+// border on the right for side by side panels
+@include mq-medium {
+    .list-panel {
+        border-bottom: 0;
+        border-right: 1px solid #e7e7e7;
+    }
 }

--- a/extension/css/inspector/partials/inspector/_inspector-panel.scss
+++ b/extension/css/inspector/partials/inspector/_inspector-panel.scss
@@ -1,7 +1,3 @@
-html, body {
-    height: 100%;
-}
-
 .fill {
     height: 100%;
     overflow: hidden;

--- a/extension/css/inspector/partials/mixins/_media-queries.scss
+++ b/extension/css/inspector/partials/mixins/_media-queries.scss
@@ -1,0 +1,32 @@
+$bp-medium: 700px;
+$bp-large: 1024px;
+
+
+@mixin mq-medium {
+  @media (min-width: #{$bp-medium}) {
+    @content;
+  }
+}
+
+@mixin mq-medium-only {
+  @media (min-width: #{$bp-medium}) and (max-width: #{$bp-large - 1px}) {
+    @content;
+  }
+}
+
+@mixin mq-large {
+  @media (min-width: #{$bp-large}) {
+    @content;
+  }
+}
+
+
+@mixin hidpi($ratio: 1.3) {
+  @media only screen and (-webkit-min-device-pixel-ratio: $ratio),
+  only screen and (min--moz-device-pixel-ratio: $ratio),
+  only screen and (-o-min-device-pixel-ratio: #{$ratio}/1),
+  only screen and (min-resolution: #{round($ratio*96)}dpi),
+  only screen and (min-resolution: #{$ratio}dppx) {
+    @content;
+  }
+}


### PR DESCRIPTION
I added a few quick little Sass mixins to handle media queries for this (and some we might want in the future)...nothing fancy for now. Then I made the panels stacked with a border at the bottom of the list at smaller widths. The panels go to the current layout of list to the left at "medium" widths and up.