### PR TITLE
Adds serializeListeningTo

### DIFF
--- a/extension/js/agent/patches/patchBackboneView.js
+++ b/extension/js/agent/patches/patchBackboneView.js
@@ -45,6 +45,11 @@
         Agent.onChange(view._events, _.partial(patchViewChanges, view));
         patchViewChanges(view);
       });
+
+      Agent.onDefined(view, '_listeningTo', function() {
+        Agent.onChange(view._events, _.partial(patchViewChanges, view));
+        patchViewChanges(view);
+      });
     });
   };
 

--- a/extension/js/agent/serializes/serializeEvents.js
+++ b/extension/js/agent/serializes/serializeEvents.js
@@ -1,7 +1,6 @@
 ;(function(Agent) {
 
-  var serializeEvent = function (eventName, event, eventIndex) {
-    var context = event.context || event.ctx;
+  var serializeEvent = function (eventName, event, eventIndex, context) {
     return {
       eventName: eventName,
       callback: Agent.inspectValue(event.callback, context),
@@ -13,9 +12,28 @@
   Agent.serializeEvents = function (events) {
     return _.chain(events).map(function(eventData, eventName) {
       return _.map(eventData, function(event, eventIndex) {
-        return serializeEvent(eventName, event, eventIndex);
+        return serializeEvent(eventName, event, eventIndex, event.context || event.ctx);
       });
     }).flatten().value();
   };
+
+
+  Agent.serializeListeningTo = function (view, listeningTo) {
+    return _.chain(listeningTo).map(function(otherObj, otherCid) {
+      var otherEvents = otherObj._events;
+      return _.map(otherEvents, function(eventData, eventName) {
+        return _.chain(eventData)
+          .filter(function(event, eventIndex) {
+            return view.cid == event.ctx.cid
+          })
+          .map(function(event, eventIndex) {
+            var otherEventName = otherCid + ' ' + eventName;
+            return serializeEvent(otherEventName, event, eventIndex, view);
+          })
+          .value();
+     })
+    }).flatten().value();
+  };
+
 
 })(Agent);

--- a/extension/js/agent/serializes/serializeView.js
+++ b/extension/js/agent/serializes/serializeView.js
@@ -17,6 +17,7 @@
     data.el = Agent.serializeElement(view.el, 'el', false);
     data.events = Agent.serializeEventsHash(view.events);
     data._events = Agent.serializeEvents(view._events);
+    data.listeningTo = Agent.serializeListeningTo(view, view._listeningTo);
     data.modelEvents = Agent.serializeEventsHash(view.modelEvents);
     data.collectionEvents = Agent.serializeEventsHash(view.collectionEvents);
     data.triggers = Agent.serializeEventsHash(view.triggers);

--- a/extension/js/inspector/app/modules/UI/views/ViewMoreInfo.js
+++ b/extension/js/inspector/app/modules/UI/views/ViewMoreInfo.js
@@ -91,6 +91,7 @@ define([
       var events = [];
       return events
         .concat(this._presentEvents(null, viewModel.get('events')))
+        .concat(this._presentListeningTo(viewModel.get('listeningTo')))
         .concat(this._presentEvents('model', viewModel.get('modelEvents')))
         .concat(this._presentEvents('collection', viewModel.get('collectionEvents')))
     },
@@ -112,7 +113,7 @@ define([
             handler = 'inline function';
           }
         } else {
-          handler = _event.eventHandler;
+          handler = _event.eventHandler || 'anonymous function';
         }
 
         var eventName = (!!this.objName) ? (this.objName + " " + _event.eventName) : _event.eventName;
@@ -122,6 +123,23 @@ define([
           handler: handler
         }
       }, {objName: objName});
+
+      return data;
+    },
+
+    _presentListeningTo: function(events) {
+      var data = _.clone(events);
+
+      if (_.isEmpty(events)) {
+        return [];
+      }
+
+      data = _.map(data, function(_event, i) {
+        return {
+          event: _event.eventName,
+          handler:_event.callback.key || _event.callback.inspect
+        }
+      });
 
       return data;
     },


### PR DESCRIPTION
One of the main ways that backbone objects (views, models, etc) react to
changes in the environment is by listening to other objects
`obj.listenTo(foo, 'event', 'callback')`.

Going forward, we'll see these events in the inspector for Backbone
Views. they'll be shown in the events section w/ the other objects cid
as part of the event key

https://www.dropbox.com/s/h4dig87eki68kjo/Screenshot%202015-05-17%2016.57.37.jpg