### PR TITLE
Show list of model classes #160

### DIFF
--- a/extension/js/inspector/app/modules/Data.js
+++ b/extension/js/inspector/app/modules/Data.js
@@ -6,8 +6,9 @@ define([
   'app/modules/Data/views/Layout',
   'client',
   'app/modules/Data/models/ModelCollection',
-  'app/modules/Data/models/CollectionCollection'
-], function(Marionette, Radio, logger, Module, Layout, client, ModelCollection, CollectionCollection) {
+  'app/modules/Data/models/CollectionCollection',
+  'app/modules/Data/models/ClassCollection'
+], function(Marionette, Radio, logger, Module, Layout, client, ModelCollection, CollectionCollection, ClassCollection) {
   return Module.extend({
 
     channelName: 'data',
@@ -39,6 +40,7 @@ define([
       this.client = client;
       this.modelCollection = new ModelCollection();
       this.collectionCollection = new CollectionCollection();
+      this.classCollection = new ClassCollection();
 
       this.modelGraveyard = new ModelCollection();
       this.collectionGraveyard = new CollectionCollection();
@@ -58,6 +60,7 @@ define([
     onAgentStart: function() {
       this.collectionCollection.reset();
       this.modelCollection.reset();
+      this.classCollection.reset();
       this.modelGraveyard.reset();
       this.collectionGraveyard.reset();
     },
@@ -67,6 +70,7 @@ define([
 
       var modelData = event.data;
       this.modelCollection.add(modelData);
+      this.classCollection.add(modelData);
     },
 
     onCollectionNew: function (event) {
@@ -124,6 +128,7 @@ define([
     buildLayout: function() {
       return new Layout({
         modelCollection: this.modelCollection,
+        classCollection: this.classCollection,
         collectionCollection: this.collectionCollection
       });
     },

--- a/extension/js/inspector/app/modules/Data/models/ClassCollection.js
+++ b/extension/js/inspector/app/modules/Data/models/ClassCollection.js
@@ -1,0 +1,10 @@
+define([
+    'backbone',
+    'app/modules/Data/models/ClassModel'
+], function(Backbone, ClassModel) {
+
+    return Backbone.Collection.extend({
+        model: ClassModel
+    });
+
+});

--- a/extension/js/inspector/app/modules/Data/models/ClassModel.js
+++ b/extension/js/inspector/app/modules/Data/models/ClassModel.js
@@ -1,0 +1,7 @@
+define([
+    'backbone'
+], function(Backbone) {
+    return Backbone.Model.extend({
+        idAttribute: 'classId'
+    });
+});

--- a/extension/js/inspector/app/modules/Data/views/ClassModelList.js
+++ b/extension/js/inspector/app/modules/Data/views/ClassModelList.js
@@ -1,0 +1,31 @@
+define([
+  'marionette',
+  'util/Radio',
+  'text!templates/devTools/data/list.html',
+  'app/modules/Data/views/ClassModelRow',
+], function(Marionette, Radio, tpl, ClassModelRow) {
+
+  return Marionette.CompositeView.extend({
+    template: tpl,
+
+    childViewContainer: '[data-child-view-container]',
+
+    attributes: {
+      view: 'list'
+    },
+
+    childView: ClassModelRow,
+
+    dataCommands: {
+      'unhighlight-rows': 'unhighlightRows'
+    },
+
+    initialize: function() {
+      Radio.connectCommands('data', this.dataCommands, this);
+    },
+
+    unhighlightRows: function() {
+      this.children.invoke('unhighlightRow');
+    }
+  });
+});

--- a/extension/js/inspector/app/modules/Data/views/ClassModelRow.js
+++ b/extension/js/inspector/app/modules/Data/views/ClassModelRow.js
@@ -1,6 +1,6 @@
 define([
   'marionette',
-  'text!templates/devTools/data/row.html',
+  'text!templates/devTools/data/class-model-row.html',
   'util/Radio',
 ], function(Marionette, tpl, Radio) {
   return Marionette.ItemView.extend({
@@ -18,8 +18,7 @@ define([
 
     events: {
       "click @ui.moreInfoLink": "onClickInfo",
-      "click @ui.log": 'onClickLog',
-      "click @ui.classId": 'onClickClassId'
+      "click @ui.log": 'onClickLog'
     },
 
     modelEvents: {
@@ -44,12 +43,6 @@ define([
     onClickLog: function() {
       Radio.command('data', 'log', {
         cid: this.model.get('cid')
-      });
-    },
-
-    onClickClassId: function() {
-      Radio.command('data', 'show:classCollectionModels', {
-        classId: this.model.id
       });
     },
 

--- a/extension/js/inspector/app/modules/Data/views/Layout.js
+++ b/extension/js/inspector/app/modules/Data/views/Layout.js
@@ -4,11 +4,14 @@ define([
   "text!templates/devTools/data/layout.html",
   "util/Radio",
   'app/modules/Data/views/ModelList',
+  'app/modules/Data/views/ClassModelList',
   'app/modules/Data/views/ModelInfo',
   'app/modules/Data/views/CollectionInfo',
   'app/modules/Data/views/CollectionList',
   'util/presenters/currentValue'
-], function(Backbone, Marionette, tpl, Radio, ModelList, ModelInfo, CollectionInfo, CollectionList, currentValue) {
+], function(
+    Backbone, Marionette, tpl, Radio, ModelList, ClassModelList, ModelInfo,
+    CollectionInfo, CollectionList, currentValue) {
 
   return Marionette.LayoutView.extend({
 
@@ -34,7 +37,8 @@ define([
     },
 
     dataCommands: {
-      'show:info': 'showInfo'
+      'show:info': 'showInfo',
+      'show:classCollectionModels': 'showClassCollectionModels'
     },
 
     viewModelEvents: {
@@ -61,7 +65,7 @@ define([
 
       if (this.viewModel.get('active') === 'model') {
         list = new ModelList({
-          collection: this.options.modelCollection
+          collection: this.options.classCollection
         })
       } else {
         list = new CollectionList({
@@ -89,12 +93,24 @@ define([
       }
     },
 
+    showClassCollectionModels: function(opt) {
+      var filteredList = this.options.modelCollection.filter(function(model) {
+        return model.get('classId') === opt.classId
+      });
+
+      var list = new ClassModelList({
+        collection: new Backbone.Collection(filteredList)
+      });
+
+      this.getRegion('list').show(list);
+    },
+
     serializeData: function() {
       var data = {};
       data.active_nav = currentValue(
         ['model', 'collection'],
         this.viewModel.get('active')
-      )
+      );
       return data;
     }
 

--- a/extension/templates/devTools/data/class-model-row.html
+++ b/extension/templates/devTools/data/class-model-row.html
@@ -1,0 +1,14 @@
+<td class="u-text--nowrap">{{cid}}</td>
+
+<td data-action="info">
+  <a href="#">
+    {{title_summary}}
+  </a>
+</td>
+
+<td>
+  <span
+          data-action='log'
+          alt='see model in the console'
+          class="right-button glyphicon glyphicon-download-alt"></span>
+</td>

--- a/extension/templates/devTools/data/row.html
+++ b/extension/templates/devTools/data/row.html
@@ -1,4 +1,8 @@
-<td class="u-text--nowrap">{{cid}} - {{classId}}</td>
+<td class="u-text--nowrap">
+  <a href="#">
+    {{classId}}
+  </a>
+</td>
 
 <td data-action="info">
   <a href="#">


### PR DESCRIPTION
This PR has the initial setup for issue #160.
Note one caveat is that once you're in the model instance collection view, you can't go back to your previous view unless you click "Collections" then back to "Models".

The plan is to update the UI later to be an accordion-type view where you will always see the class model list, and clicking a down arrow will toggle open the model instance collection view. Then, the arrow will turn into an up arrow, and clicking it will collapse the sub-view.

/cc @kford55

![inspector](https://cloud.githubusercontent.com/assets/1666031/10836779/074e8988-7e88-11e5-8c49-531771d5274d.gif)
