### PR TITLE
support-for-templates-having-iframes

### DIFF
--- a/extension/js/agent/utils/inspectValue.js
+++ b/extension/js/agent/utils/inspectValue.js
@@ -19,8 +19,14 @@
   }
 
   var formatJquery = function(value) {
-    var elem = value[0] ? '<'+value[0].tagName.toLowerCase()+'>' : '';
-    return '<jQuery ' + elem + '>';
+    var elem = value[0];
+    var tagName;
+    if (!elem || !elem.tagName) {
+      tagName = '';
+    } else {
+      tagName = '<'+value[0].tagName.toLowerCase()+'>';
+    }
+    return '<jQuery ' + tagName + '>';
   }
 
   var formatArray = function(value) {


### PR DESCRIPTION
- when a iframe is present in a template, the formatJquery method in inspectValue.js throws an error
- this is because, an iframe contains an embeded document, which doesn't have a tagName
- Thus, checking whether tagName is not blank, fixes the error