### PR TITLE
Watch for Marionette.Module property

### DIFF
--- a/extension/js/agent/patches/patchWindow.js
+++ b/extension/js/agent/patches/patchWindow.js
@@ -3,7 +3,7 @@
   var waitForMarionetteLoad = function(object, callback) {
     Agent.onObjectAndPropertiesSetted(
       object,
-      'Marionette', ['Application'],
+      'Marionette', ['Application', 'Module'],
       callback
     );
   }


### PR DESCRIPTION
Watch also Marionette.Module property so only when all properties are set, the Mn instance is patched

Fixes #310 #311 