### PR TITLE
Fix random fails in tests

### DIFF
--- a/extension/js/agent/utils/lazyWorker.js
+++ b/extension/js/agent/utils/lazyWorker.js
@@ -17,6 +17,10 @@
       // this.logSize();
     },
 
+    onDestroy: function() {
+      this.queue = [];
+    },
+
     push: function(job) {
       // console.log('** callee', Agent.stackFrame(8));
       // console.log('push called', this.queue.length, new Date() - this.initTime);

--- a/extension/js/agent/utils/lazyWorker.js
+++ b/extension/js/agent/utils/lazyWorker.js
@@ -17,10 +17,6 @@
       // this.logSize();
     },
 
-    onDestroy: function() {
-      this.queue = [];
-    },
-
     push: function(job) {
       // console.log('** callee', Agent.stackFrame(8));
       // console.log('push called', this.queue.length, new Date() - this.initTime);

--- a/extension/js/test/unit/agent/utils/lazyWorker.spec.js
+++ b/extension/js/test/unit/agent/utils/lazyWorker.spec.js
@@ -108,14 +108,14 @@ describe('lazyWorker', function() {
       this.job1 = sinon.stub();
       this.worker.push({
         context: this,
-        callback: function() {fib(2000000); this.job1();},
+        callback: function() {fib(4000000); this.job1();},
         args: []
       });
 
       this.job2 = sinon.stub();
       this.worker.push({
         context: this,
-        callback: function() {fib(2000000); this.job2();},
+        callback: function() {fib(4000000); this.job2();},
         args: []
       });
 

--- a/extension/js/test/unit/agent_test_setup.js
+++ b/extension/js/test/unit/agent_test_setup.js
@@ -54,7 +54,7 @@
   });
 
   afterEach(function () {
-      window.lazyWorker.destroy();
+      window.lazyWorker.queue = [];
       this.sinon.restore();
       this.clearFixtures();
       delete window.patchedBackbone;

--- a/extension/js/test/unit/agent_test_setup.js
+++ b/extension/js/test/unit/agent_test_setup.js
@@ -54,6 +54,7 @@
   });
 
   afterEach(function () {
+      window.lazyWorker.destroy();
       this.sinon.restore();
       this.clearFixtures();
       delete window.patchedBackbone;


### PR DESCRIPTION
Following #282, i found that the reason to the test fails at different, random places is due to jobs added to `Agent.lazyWorker` in previous tests being executed after the test finished.

The PR adds an `onDestroy` handler to` LazyWorker` resetting the job queue and calls `destroy` method after each test. `destroy` is used only in tests and is alternatively possible to reset `lazyWorker.queue` directly.

Now, running tests in node only one test fails and always ('LazyWorker slow jobs added calls stop work').
But i found, by uncommenting debug code, that the problem is the first job not being sufficiently slow. In one of my runs, the first job ran 202 microseconds after worker init and the second job 229 microseconds a difference of 27 microseconds, not enough to trigger the `stopWork` method.

To emulate a slow job the test calls `fib(2000000)`. Probably at the time the test was written this code would never run shorter than 50 microseconds but now with advances in V8 and faster computers this is no longer true. We need a more accurate slow code.