### PR TITLE
Send report message timestamp as a separate property 

### DIFF
--- a/extension/js/agent/components/util/sendAppComponentReport.js
+++ b/extension/js/agent/components/util/sendAppComponentReport.js
@@ -7,12 +7,13 @@
       report = report || {};
       options = options || {};
 
-      // the timestamp is tipicaly used by the panel to exclude old reports
-      report.timestamp = new Date().getTime();
+      // the timestamp is typically used by the panel to exclude old reports
+      var timestamp = new Date().getTime();
 
       Agent.sendMessage({
           name: 'agent:' + name,
-          data: report
+          data: report,
+          timestamp: timestamp
       }, options);
   };
 

--- a/extension/js/inspector/client/inspectedPage.js
+++ b/extension/js/inspector/client/inspectedPage.js
@@ -37,8 +37,7 @@ define([
 
               _.each(messages, function(message) {
                 if (message && message.target == "page") {
-                    message.data = message.data || {};
-                    this.trigger(message.name, message.data);
+                    this.trigger(message.name, message.data || {}, message.timestamp);
                 }
               }, this);
             }, this));


### PR DESCRIPTION
Currently the timestamp of a report message is passed as a property of data

One of the side effects is the UI tree shows a dummy timestamp region