### PR TITLE
Ensure UI tree node always has a id

### DIFF
--- a/extension/js/agent/actions/regionInspector.js
+++ b/extension/js/agent/actions/regionInspector.js
@@ -41,7 +41,7 @@
     var regions = (obj._regionManager || obj.regionManager)._regions;
     _.each(regions, function(region, regionName) {
       var subRegions = _regionInspector(region.currentView, shouldSerialize);
-      subRegions._region = 'region' //region;
+      subRegions._region = region.cid || region.__marionette_inspector__cid;
       subViews[regionName] = subRegions;
     }, this);
     return subViews;

--- a/extension/js/inspector/app/components/tree/models/Node.js
+++ b/extension/js/inspector/app/components/tree/models/Node.js
@@ -82,7 +82,7 @@ define([
         query[this.idAttribute] = node.id;
         var newNodeNodes = _.findWhere(newNodes, query);
 
-        if (newNodeNodes.nodes) {
+        if (newNodeNodes && newNodeNodes.nodes) {
           node.updateNodes(newNodeNodes.nodes)
         }
       }, this);

--- a/extension/js/inspector/app/modules/UI/models/UiData.js
+++ b/extension/js/inspector/app/modules/UI/models/UiData.js
@@ -57,7 +57,7 @@ define([
     },
 
     _buildViewTree: function(regionTree, subPath, idPath) {
-      var viewData = {};
+      var cid, viewData = {};
       subPath = subPath || '';
       regionTree = regionTree || {};
 
@@ -72,8 +72,14 @@ define([
         viewData.path = subPath;
         viewData.name = _.last(subPath.split('.'));
         if (_.has(regionTree, '_view')) {
-          viewData.cid = regionTree._view.cid;
-          viewData.idPath = idPath.concat(regionTree._view.cid);
+          cid = regionTree._view.cid;
+          viewData.hasView = true;
+        } else if (_.has(regionTree, '_region')) {
+          cid = regionTree._region;
+        }
+        if (cid) {
+          viewData.cid = cid;
+          viewData.idPath = idPath.concat(cid);
         }
       }
 

--- a/extension/js/inspector/app/modules/UI/views/ViewTree.js
+++ b/extension/js/inspector/app/modules/UI/views/ViewTree.js
@@ -60,7 +60,7 @@ define([
     onClickMoreInfo: function(e) {
       e.stopPropagation()
 
-      if (!this.model.has('cid')) {
+      if (!this.model.get('hasView')) {
         this.unhighlightRow();
         Radio.request('ui', 'empty:moreInfo', this.model.pick('name', 'path'));
         Radio.request('app', 'navigate', 'data/emptyview');


### PR DESCRIPTION
Currently, a UI tree node uses the view.cid property as the idAttribute ('cid'). When the region is empty the 'cid' field is undefined

This has, at least two issues:

 - An access violation occurs in https://github.com/marionettejs/marionette.inspector/blob/master/extension/js/inspector/app/components/tree/models/Node.js#L85 when there's no cid / id

- When there at least two empty regions and one of them shows a view, will duplicate entry. This occurs because the previous empty node will be in nodesToUpdate https://github.com/marionettejs/marionette.inspector/blob/master/extension/js/inspector/app/components/tree/models/Node.js#L57 (undefined will be in the currentNodeIds ) and the node with the view will be in nodesToAdd

This PR assign the region cid when the region is empty and set a property hasView to be checked in the panel