### PR TITLE
Highlight row with empty region

### DIFF
--- a/extension/js/inspector/app/modules/UI/views/Layout.js
+++ b/extension/js/inspector/app/modules/UI/views/Layout.js
@@ -94,6 +94,7 @@ define([
     },
 
     emptyMoreInfo: function(data) {
+      this.highlightRow(data);
       this.getRegion('viewMoreInfo').show(new EmptyMoreInfo({
         name: data.name,
         path: data.path

--- a/extension/js/inspector/app/modules/UI/views/ViewTree.js
+++ b/extension/js/inspector/app/modules/UI/views/ViewTree.js
@@ -61,8 +61,7 @@ define([
       e.stopPropagation()
 
       if (!this.model.get('hasView')) {
-        this.unhighlightRow();
-        Radio.request('ui', 'empty:moreInfo', this.model.pick('name', 'path'));
+        Radio.request('ui', 'empty:moreInfo', this.model.pick('name', 'path', 'cid'));
         Radio.request('app', 'navigate', 'data/emptyview');
         return;
       }


### PR DESCRIPTION
Now that there's a side panel showing the region status and the node has a cid is possible to highlight the empty region when selected.

Improves usability when there are two regions with same name in different levels and the selected is empty