### PR TITLE
Add checks in WatchJS to avoid endless loop when watching view._events

### DIFF
--- a/extension/js/lib/watchjs/src/watch.js
+++ b/extension/js/lib/watchjs/src/watch.js
@@ -60,7 +60,7 @@
             } else {
                 for(var i in a){
                     if (a.hasOwnProperty(i)) {
-                        if(b[i] === undefined) {
+                        if(b && !b.hasOwnProperty(i)) {
                             aplus.push(i);
                         }
                     }
@@ -74,7 +74,7 @@
             } else {
                 for(var j in b){
                     if (b.hasOwnProperty(j)) {
-                        if(a[j] === undefined) {
+                        if(a && !a.hasOwnProperty(j)) {
                             bplus.push(j);
                         }
                     }
@@ -210,7 +210,7 @@
     };
 
     var watchOne = function (obj, prop, watcher, level, addNRemove) {
-        if ((typeof obj == "string") || (!(obj instanceof Object) && !isArray(obj))) { //accepts only objects and array (not string)
+        if ((typeof obj == "string") || (!(obj instanceof Object) && !isArray(obj)) || prop instanceof Object) { //accepts only objects and array (not string)
             return;
         }
 


### PR DESCRIPTION
This fix a nasty bug that was making the Agent send messages continuously to the panel. Some background at https://github.com/melanke/Watch.JS/pull/110