### PR TITLE
Replace Chrome specific API and use fetch instead of $.ajax (fix compatibility with Firefox)

### DIFF
--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -8,7 +8,7 @@
 var panelPorts = {};
 
 // Panel registration
-chrome.extension.onConnect.addListener(function(port) {
+chrome.runtime.onConnect.addListener(function(port) {
     if (port.name !== "devtoolspanel") return;
 
     port.onMessage.addListener(function(message) {

--- a/extension/js/inspector/panelPort.js
+++ b/extension/js/inspector/panelPort.js
@@ -1,7 +1,7 @@
 define([], function() {
     // Establish a bidiretional communication port with the background
     var tabId = chrome.devtools.inspectedWindow.tabId;
-    var panelPort = chrome.extension.connect({name: "devtoolspanel"});
+    var panelPort = chrome.runtime.connect({name: "devtoolspanel"});
 
     panelPort.postMessage({
         name: "identification",

--- a/extension/js/inspector/utils.js
+++ b/extension/js/inspector/utils.js
@@ -1,20 +1,24 @@
-define(["underscore", "jquery"], function(_, $) {
+define([], function() {
     var utils = new (function() {
-
-        this.initialize = function() {
-            _.bindAll(this, 'httpRequest');
-        };
-
         this.httpRequest = function(method, url, callback, disableCaching) {
             var requestObj = {
-                type: method,
-                url: url
+                method: method
             };
             if (disableCaching === true) {
-                requestObj.cache = false;
+                requestObj.cache = 'no-cache';
             }
 
-            $.ajax(requestObj).always(callback); // the callback is called also if the request fails
+            fetch(url, requestObj)
+              .then(function(response) {
+                if (response.status >= 200 && response.status < 300) {
+                  response.text().then(callback);  
+                } else {  
+                  console.error('Error fetching ', url, ' - ', response.statusText);  
+                }
+              })
+              .catch(function() {
+                console.error('Error fetching ', url);
+              })
         };
 
         // String utility functions.
@@ -50,8 +54,6 @@ define(["underscore", "jquery"], function(_, $) {
                 return target;
             }
         }
-
-        this.initialize();
     })();
     return utils;
 });


### PR DESCRIPTION
Fixes #218
Replace specific Chrome api
Also jQuery ajax was failing in Firefox. Replaced it by native fetch api