### PR TITLE
Update property-tree li style to avoid text clobbering

### DIFF
--- a/extension/css/inspector/partials/inspector/_inspector-sidebar.scss
+++ b/extension/css/inspector/partials/inspector/_inspector-sidebar.scss
@@ -223,10 +223,10 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
-    -webkit-user-select: text;
+    user-select: text;
     cursor: default;
-    padding-top: 2px;
-    line-height: 12px;
+    padding-top: 1px;
+    line-height: 13px;
 }
 
 .properties-tree li.parent {


### PR DESCRIPTION
The sidebar list item text is being clobbered by below item. This PR fixes it
 
It also uses the unprefixed user-select rule