### PR TITLE
Rework how Marionette is detected when using script tag

### DIFF
--- a/extension/js/agent/patches/patchWindow.js
+++ b/extension/js/agent/patches/patchWindow.js
@@ -3,8 +3,15 @@
   var waitForMarionetteLoad = function(object, callback) {
     Agent.onObjectAndPropertiesSetted(
       object,
-      'Marionette', ['Application', 'Module'],
-      callback
+      'Marionette', ['VERSION'],
+      function (Marionette) {
+        var mnVersion = Marionette.VERSION && Marionette.VERSION[0];
+        if (mnVersion === '2') {
+          Agent.onceSetted(Marionette, 'Module', callback);
+        } else {
+          callback();
+        }
+      }
     );
   }
 


### PR DESCRIPTION
Fixes loading the inspector when Marionette 3 is used through script tag 