### PR TITLE
Optimize knownType and objectPath

### DIFF
--- a/extension/js/agent/patches/patchMarionette.js
+++ b/extension/js/agent/patches/patchMarionette.js
@@ -65,6 +65,8 @@
 
       _.each(marionetteClasses, Agent.patchBackboneTrigger, this);
 
+      Agent.initializeKnownTypes();
+
       Agent.markEvent('start', {
         marionette_version: Marionette.VERSION,
         backbone_version: Backbone.VERSION,

--- a/extension/js/agent/serializes/serializeView.js
+++ b/extension/js/agent/serializes/serializeView.js
@@ -5,9 +5,10 @@
     // debug.log('serializeView', view)
 
     if (!_.isObject(view)) {
-      return {};
+      return data;
     }
 
+    var knownType = Agent.knownType(view);
 
     data.cid = view.cid;
     data.isLoading = false; // set when a view is registered, but not serialized
@@ -25,8 +26,8 @@
     data.ancestorInfo = Agent.ancestorInfo(view);
     data._requirePath = view._requirePath;
     data._className = Agent.serializeClassName(view);
-    data.parentClass = Agent.isKnownType(view) ? Agent.knownType(view).name : '';
-    data.inspect = Agent.inspectValue(view);
+    data.parentClass = knownType ? knownType.name : '';
+    data.inspect = Agent.inspectValue(view, undefined, knownType);
     data.classId = Agent.getHiddenProperty(view, 'classId');
 
     if (view.model) {

--- a/extension/js/agent/utils/inspectValue.js
+++ b/extension/js/agent/utils/inspectValue.js
@@ -32,17 +32,15 @@
   var formatArray = function(value) {
     if (value.length === 0) { return '[]'; }
 
-    var ret;
+    var ret, obj = value[0], knownType = Agent.knownType(obj);
 
-    if (Agent.isKnownType(value[0])) {
-      ret = Agent.knownTypeString(value[0]);
+    if (knownType) {
+      ret = knownType.toString(obj);
     } else {
-      ret = inspect(value[0]);
+      ret = inspect(obj);
     }
 
-    var suffix = ' ]';
-
-    if(value.length > 1) suffix = ', ... ]';
+    var suffix = (value.length > 1) ? ', ... ]' : ' ]';
 
     return '[ ' + ret + suffix;
   }
@@ -69,7 +67,9 @@
       }
       t = typeOf(v);
 
-      if (Agent.isKnownType(v)) { v = Agent.knownTypeString(v); }
+      var knownType = Agent.knownType(v);
+
+      if (knownType) { v = knownType.toString(v); }
       else if (v === 'toString') { continue; } // ignore useless items
       else if (t === 'function') { v = 'function() {}'; }
       else if (t === 'array') { v = '[Array : ' + v.length + ']'; }
@@ -78,9 +78,7 @@
       ret.push(key + ': ' + v);
     };
 
-    var suffix = ' }';
-
-    if(broken) suffix = ' ...}';
+    var suffix = broken ? ' ...}' : ' }';
 
     return '{ ' + ret.join(', ') + suffix;
   }
@@ -120,11 +118,10 @@
    *   {type:'object', inspect:"{a: 2, b: 3, ... }"}
    *
    */
-  Agent.inspectValue = function(value, object) {
-    var key = this.findKey(object, value);
+  Agent.inspectValue = function(value, object, type = this.knownType(value)) {
+    var key = object ? this.findKey(object, value) : '';
 
-    if (this.isKnownType(value)) {
-      var type = this.knownType(value);
+    if (type) {
       return {
         type: 'type-' + type.name,
         inspect: type.str,

--- a/extension/js/agent/utils/inspectValue.js
+++ b/extension/js/agent/utils/inspectValue.js
@@ -118,7 +118,8 @@
    *   {type:'object', inspect:"{a: 2, b: 3, ... }"}
    *
    */
-  Agent.inspectValue = function(value, object, type = this.knownType(value)) {
+  Agent.inspectValue = function(value, object, type) {
+    if (typeof type === 'undefined') type = this.knownType(value);
     var key = object ? this.findKey(object, value) : '';
 
     if (type) {

--- a/extension/js/agent/utils/knownTypes.js
+++ b/extension/js/agent/utils/knownTypes.js
@@ -4,36 +4,23 @@
     var name = obj._className ? obj._className : this.className;
     var cid = _.isFunction(this.cid) ? this.cid(obj) : this.cid;
     return '<' + name + ' ' + cid + '>';
-  }
-
-  Agent.isKnownType = function(obj) {
-    return !!Agent.knownType(obj);
-  };
-
-  Agent.knownTypeString = function(obj) {
-    var type = Agent.knownType(obj);
-
-    if (!type) {
-      return ''
-    }
-
-     return type.toString(obj);
   };
 
   Agent.knownType = function (o) {
-    if (_.isUndefined(Agent.patchedBackbone) || _.isUndefined(Agent.patchedMarionette)) {
-      return;
+    if (!Object.keys(Agent._knownTypes).length) {
+      debug.log('knownType called with knownTypes not initialized');
+      return null;
     }
 
-    var type = _.find(Agent.knownTypes(), function(knownType) {
+    var key = _.findKey(Agent._knownTypes, function(knownType) {
       return (o instanceof knownType.type)
-    }, Agent);
+    });
 
-    if (!type) {
-      return;
+    if (!key) {
+      return null;
     }
 
-    var type = _.clone(type);
+    var type = _.clone(Agent._knownTypes[key]);
     type.str = type.toString(o);
     type.cid = type.cid(o);
 
@@ -42,8 +29,8 @@
 
   Agent._knownTypes = {};
 
-  Agent.knownTypes = function() {
-    var knownTypes = {};
+  Agent.initializeKnownTypes = function() {
+    var knownTypes = Object.create(null);
 
     if (!_.isEmpty(Agent._knownTypes)) {
       return Agent._knownTypes;
@@ -122,7 +109,7 @@
         type: Agent.patchedMarionette.Region,
         name: 'marionette-region',
         className: 'Marionette.Region',
-        cid: function(obj) { return '' },
+        cid: function(obj) { return obj.cid || '' },
         toString: toString
       },
 
@@ -178,7 +165,7 @@
           type: Agent.patchedMarionette.Object,
           name: 'marionette-object',
           className: 'Marionette.Object',
-          cid: function(obj) { return obj.__marionette_inspector__cid },
+          cid: function(obj) { return obj.cid || obj.__marionette_inspector__cid },
           toString: toString
         }
       });
@@ -190,7 +177,7 @@
           type: Agent.patchedMarionette.Behavior,
           name: 'marionette-behavior',
           className: 'Marionette.Behavior',
-          cid: function(obj) { return obj.__marionette_inspector__cid },
+          cid: function(obj) { return obj.cid || obj.__marionette_inspector__cid },
           toString: toString
         }
       });

--- a/extension/js/agent/utils/objectPath.js
+++ b/extension/js/agent/utils/objectPath.js
@@ -1,6 +1,7 @@
 ;(function(Agent) {
 
-  Agent.objectPath = function (obj, path, defaultValue, pathIndex = 0) {
+  Agent.objectPath = function (obj, path, defaultValue, pathIndex) {
+    if (typeof pathIndex === 'undefined') pathIndex = 0;
     if (!obj) return defaultValue;
     if (path.length === pathIndex) return obj;
     if (typeof path === "string") path = path.split(".");

--- a/extension/js/agent/utils/objectPath.js
+++ b/extension/js/agent/utils/objectPath.js
@@ -1,18 +1,17 @@
 ;(function(Agent) {
 
-  Agent.objectPath = function (obj, path, defaultValue) {
-    if (typeof path == "string") path = path.split(".");
-    if (obj === undefined) return defaultValue;
-    if (path.length === 0) return obj;
-    if (obj === null) return defaultValue;
+  Agent.objectPath = function (obj, path, defaultValue, pathIndex = 0) {
+    if (!obj) return defaultValue;
+    if (path.length === pathIndex) return obj;
+    if (typeof path === "string") path = path.split(".");
 
-    var part = _.first(path);
-    if (part == "") {
+    var part = path[pathIndex];
+    if (!part) {
       return obj;
     }
 
     try {
-      return Agent.objectPath(obj[part], _.rest(path), defaultValue);
+      return Agent.objectPath(obj[part], path, defaultValue, ++pathIndex);
     }
     catch (error) {
       return defaultValue;

--- a/extension/js/test/unit/agent_test_setup.js
+++ b/extension/js/test/unit/agent_test_setup.js
@@ -48,7 +48,6 @@
       window.Marionette = window.MarionetteFactory(Backbone);
       window.patchBackbone(Backbone);
       window.patchMarionette(Backbone, Marionette);
-      window.knownTypes();
       window.lazyWorker = new window.LazyWorker();
 
   });


### PR DESCRIPTION
Part of #352 
objectPath is the main bottleneck when serializing view or events. It's called very often. There are two factors that make it slow: the call to _.rest and String.split. This PR avoids calling _.rest by passing the path array alongside the index in nested calls. The split still there to, maybe, be handled  later

knownType is also called a lot. This PR make its initialization explicit instead of by demand and reduce the number of calls to it.  