### PR TITLE
Reduce the number of times a view is serialized

### DIFF
--- a/extension/js/agent/patches/patchBackboneView.js
+++ b/extension/js/agent/patches/patchBackboneView.js
@@ -1,6 +1,7 @@
 ;(function(Agent){
 
-  var patchViewChanges = _.debounce(function(view, prop, action, difference, oldValue) {
+  var patchViewChanges = function(view, prop, action, difference, oldValue) {
+    debug.log('view:change', view.cid);
     Agent.lazyWorker.push({
       context: Agent,
       args: [view],
@@ -11,49 +12,55 @@
         });
       }
     });
-  }, 200);
+  };
+
+  var onNewViewInstance = function(view) { // on new instance
+    debug.log('new view instance:', view.cid);
+    // flag to not trigger view:change when is registering
+    var isRegisteringView = true;
+    var viewChanged = _.debounce(_.partial(patchViewChanges, view), 0);
+    Agent.lazyWorker.push({
+      context: Agent,
+      args: [view],
+      callback: function(view) {
+        // registra il nuovo componente dell'app
+        var data = Agent.serializeView(view);
+        Agent.registerAppComponent('View', view, data);
+      }
+    });
+
+    // set class name if we can
+    if (view._requirePath) {
+      view._className = _.last(view._requirePath.split('/'));
+    }
+
+    // Patcha i metodi del componente dell'app
+    Agent.patchAppComponentTrigger(view, 'view');
+
+    Agent.onDefined(view, 'ui', function() {
+      Agent.onChange(view.ui, viewChanged);
+      if (!isRegisteringView) viewChanged();
+    });
+
+    Agent.onDefined(view, '_events', function() {
+      Agent.onChange(view._events, viewChanged);
+      if (!isRegisteringView) viewChanged();
+    });
+
+    Agent.onDefined(view, '_listeningTo', function() {
+      Agent.onChange(view._listeningTo, viewChanged);
+      if (!isRegisteringView) viewChanged();
+    });
+
+    isRegisteringView = false;
+  };
 
   // @private
   Agent.patchBackboneView = function(BackboneView) {
     debug.log('Backbone.View detected');
 
-    Agent.patchBackboneComponent(BackboneView, function(view) { // on new instance
-      Agent.lazyWorker.push({
-        context: Agent,
-        args: [view],
-        callback: function(view) {
-          // registra il nuovo componente dell'app
-          var data = Agent.serializeView(view)
-          Agent.registerAppComponent('View', view, data);
-          Agent.sendAppComponentReport('view:change', {
-            data: data,
-            cid: view.cid
-          });
-        }
-      });
-
-      // set class name if we can
-      if (view._requirePath) {
-        view._className = _.last(view._requirePath.split('/'));
-      }
-
-      // Patcha i metodi del componente dell'app
-      Agent.patchAppComponentTrigger(view, 'view');
-
-      Agent.onDefined(view, 'ui', function() {
-        Agent.onChange(view.ui, _.partial(patchViewChanges, view));
-        patchViewChanges(view);
-      });
-
-      Agent.onDefined(view, '_events', function() {
-        Agent.onChange(view._events, _.partial(patchViewChanges, view));
-        patchViewChanges(view);
-      });
-
-      Agent.onDefined(view, '_listeningTo', function() {
-        Agent.onChange(view._listeningTo, _.partial(patchViewChanges, view));
-        patchViewChanges(view);
-      });
+    Agent.patchBackboneComponent(BackboneView, function (view) {
+      _.defer(onNewViewInstance, view);
     });
   };
 


### PR DESCRIPTION
Part of #352 

Currently when a view is created is serialized from 2 to 4 times according to what events are configured.

This PR makes the view be serialized only once when created. Also fixes a bug where, after more than one view is changed, only the last one would be updated