### PR TITLE
Decrease the defertime of lazyworker by 20%

### DIFF
--- a/extension/js/agent/utils/lazyWorker.js
+++ b/extension/js/agent/utils/lazyWorker.js
@@ -10,7 +10,7 @@
   _.extend(Agent.LazyWorker.prototype, Backbone.Events, {
 
     // time to wait until starting work
-    deferTime: 200,
+    deferTime: 160,
 
     // time to work and potentially freeze the screen
     workTime: 80,


### PR DESCRIPTION
Part of #352 

Decrease the defertime to 160. Given that the recent changes reduces the number of actions to execute should have no significant impact.

Also more computation can be in 160ms today than 200ms two years ago