### PR TITLE
Remove BackboneEvents from agent build

### DIFF
--- a/extension/js/agent/build/core.js
+++ b/extension/js/agent/build/core.js
@@ -7,11 +7,6 @@ if (typeof window._ == "undefined") {
 // @include ../../lib/nanodom.js
 var nanodom = this.nanodom;
 
-// @include ../../lib/backbone-events-standalone/backbone-events-standalone.js
-
-// define BackboneEvents locally in the agent closure
-var BackboneEvents = this.BackboneEvents || window.BackboneEvents;
-
 var Agent = this;
 
  /*

--- a/extension/js/agent/utils/lazyWorker.js
+++ b/extension/js/agent/utils/lazyWorker.js
@@ -7,7 +7,7 @@
     // this.logSize();
   };
 
-  _.extend(Agent.LazyWorker.prototype, BackboneEvents, {
+  _.extend(Agent.LazyWorker.prototype, {
 
     // time to wait until starting work
     deferTime: 160,
@@ -16,6 +16,9 @@
     workTime: 80,
 
     jobId: 0,
+
+    // abstract method
+    trigger: function() {},
 
     push: function(job) {
       // console.log('** callee', Agent.stackFrame(8));

--- a/extension/js/test/unit/agent_test_setup.js
+++ b/extension/js/test/unit/agent_test_setup.js
@@ -50,6 +50,7 @@
 
         window.startAnalytics();
         window.Backbone = window.BackboneFactory(window._, window.jQuery || window.$);
+        Object.assign(window.LazyWorker.prototype, window.Backbone.Events);
         window.Marionette = window.MarionetteFactory(Backbone);
         window.patchBackbone(Backbone);
         window.patchMarionette(Backbone, Marionette);


### PR DESCRIPTION
BackboneEvents  is used only in tests.

Move the LazyWork prototype patch to test setup and remove from agent build