### PR TITLE
Fix serialization of trigger arguments

### DIFF
--- a/extension/js/agent/patches/patchAppComponentTrigger.js
+++ b/extension/js/agent/patches/patchAppComponentTrigger.js
@@ -36,7 +36,7 @@
       startTime: start,
       endTime: end,
       eventName: eventName,
-      args: _.map(args, Agent.inspectValue, Agent),
+      args: _.map(args, arg => Agent.inspectValue(arg)),
       depth: depth,
       context: Agent.inspectValue(ctx),
       listeners: listeners


### PR DESCRIPTION
The arguments were not being serialized correctly because the arguments passed by _.map does not match the expected by `inspectValue`